### PR TITLE
Add conditional for redhat

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,6 +27,7 @@
     permanent: yes
   notify: restart firewalld
   tags: bind
+  when: ansible_distribution == "Redhat" and ansible_distribution_major_version == "7"
 
 - name: Create serial
   command: date +%y%m%d%H


### PR DESCRIPTION
Added a conditional so that the firewalld executes only on Red Hat 7. As it turns out, the role actually works very well on Red Hat 6 - we just need this to ensure that it firewalld part doesn't error out during the deployment.