### PR TITLE
Find named-checkzone in path on CentOS 6

### DIFF
--- a/tasks/master.yml
+++ b/tasks/master.yml
@@ -22,7 +22,7 @@
     group: named
     mode: "0640"
     setype: named_zone_t
-    validate: '/sbin/named-checkzone -d {{ bind_zone_name }} %s'
+    validate: 'named-checkzone -d {{ bind_zone_name }} %s'
   notify: restart bind
   tags: bind
 


### PR DESCRIPTION
The other references to `named-checkzone` don't include `/sbin`; this just makes the calls consistent.