### PR TITLE
Allow CNAME-only records

### DIFF
--- a/templates/bind_zone.j2
+++ b/templates/bind_zone.j2
@@ -32,12 +32,14 @@ $TTL {{ bind_zone_ttl }}
 
 {% if bind_zone_hosts|length > 0 %}
 {% for host in bind_zone_hosts %}
+{% if host.ip is defined %}
 {% if host.ip is string %}
 {{ host.name.ljust(20) }} IN  A      {{ host.ip }}
 {% else %}
 {% for ip in host.ip %}
 {{ host.name.ljust(20) }} IN  A      {{ ip }}
 {% endfor %}
+{% endif %}
 {% endif %}
 {% if host.ipv6 is defined %}
 {% if host.ipv6 is string %}

--- a/templates/reverse_zone.j2
+++ b/templates/reverse_zone.j2
@@ -29,6 +29,7 @@ $ORIGIN {{ item|reverse_lookup_zone }}.
 
 {% if bind_zone_hosts|length > 1 %}
 {% for host in bind_zone_hosts %}
+{% if host.ip is defined %}
 {% if host.ip == item %}
 @ IN  PTR  {{ host.name }}.{{ bind_zone_name }}.
 {% else %}
@@ -48,6 +49,7 @@ $ORIGIN {{ item|reverse_lookup_zone }}.
 {% endif %}
 {% endif %}
 {% endfor %}
+{% endif %}
 {% endif %}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
It's sometimes useful to provide aliases for external hosts; requires a `forwarders` entry in `/etc/named.conf` to be useful (which I haven't added).
