### PR TITLE
Idempotent Zonefiles

### DIFF
--- a/IDEMPOTENT_ZONEFILES.md
+++ b/IDEMPOTENT_ZONEFILES.md
@@ -1,0 +1,1 @@
+Based on the idea and examples detailed at https://linuxmonk.ch/wordpress/index.php/2016/managing-dns-zones-with-ansible/ for the gdnsd package, I have now made changes to this role, so that the zonefiles created are fully idempotent, and thus only get updated if "real" content changes.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,8 @@
 ---
 
 # Initialise distribution-specific variables
-- include_vars: "{{ item }}"
+- name: Source specific variables
+  include_vars: "{{ item }}"
   with_first_found:
     - "{{ ansible_distribution }}.yml"
     - "{{ ansible_os_family }}.yml"
@@ -35,7 +36,31 @@
   command: date +%y%m%d%H
   register: timestamp
   changed_when: false
+  run_once: True
   tags: bind
+
+- name: Read forward zone hashes
+  shell: 'grep "^; Hash:" {{ bind_dir }}/{{ bind_zone_name }} || true'
+  changed_when: False
+  always_run: True
+  check_mode: False
+  register: forward_hashes
+
+- name: Read reverse ipv4 zone hashes
+  shell: "grep \"^; Hash:\" {{ bind_dir }}/{{ ('.'.join(item.replace(item+'.','').split('.')[::-1])) }}.in-addr.arpa || true"
+  changed_when: False
+  always_run: True
+  check_mode: False
+  register: reverse_hashes
+  with_items: "{{ bind_zone_networks }}"
+
+- name: Read reverse ipv6 zone hashes
+  shell: "grep \"^; Hash:\" {{bind_dir}}/{{ (item | ipaddr('revdns'))[-(9+(item|regex_replace('^.*/','')|int)//2):-1] }} || true"
+  changed_when: False
+  always_run: True
+  check_mode: False
+  register: reverse_hashes_ipv6
+  with_items: "{{ bind_zone_ipv6_networks }}"
 
 - include: master.yml
   when: bind_zone_master_server_ip in ansible_all_ipv4_addresses

--- a/templates/bind_zone.j2
+++ b/templates/bind_zone.j2
@@ -1,37 +1,71 @@
-; Zone file for {{ bind_zone_name }}
+{#
+ #  First create a dict holding the entire zone information and create a hash
+ #  from it, that it can be compared with subsequent task executions. In this
+ #  way the serial will only be updated if there are some content changes.
+ #}
+{% set _zone_data = {} %}
+{% set _ = _zone_data.update({'ttl': bind_zone_ttl}) %}
+{% set _ = _zone_data.update({'domain': bind_zone_name }) %}
+{% set _ = _zone_data.update({'mname': bind_zone_name_servers}) %}
+{% set _ = _zone_data.update({'aname': bind_other_name_servers}) %}
+{% set _ = _zone_data.update({'mail': bind_zone_mail_servers}) %}
+{% set _ = _zone_data.update({'rname': (( bind_zone_hostmaster_email)) + ('' if (bind_zone_hostmaster_email | search('\.')) else ('.' + _zone_data['domain']))}) %}
+{% set _ = _zone_data.update({'refresh': bind_zone_time_to_refresh}) %}
+{% set _ = _zone_data.update({'retry': bind_zone_time_to_retry}) %}
+{% set _ = _zone_data.update({'expire': bind_zone_time_to_expire}) %}
+{% set _ = _zone_data.update({'minimum': bind_zone_minimum_ttl}) %}
+{% set _ = _zone_data.update({'hosts': bind_zone_hosts }) %}
+{% set _ = _zone_data.update({'services': bind_zone_services }) %}
+{% set _ = _zone_data.update({'text': bind_zone_text }) %}
+{#
+ #  Compare the zone file hash with the current zone data hash and set serial
+ #  accordingly
+ #}
+{% set _zone = {'hash': _zone_data | string | hash('md5')} %}
+{% set _hash_serial = forward_hashes.stdout.split(' ')[2:] %}
+{% if _hash_serial and _hash_serial[0] == _zone['hash'] %}
+{%   set _ = _zone.update({'serial': _hash_serial[1]}) %}
+{% else %}
+{%   set _ = _zone.update({'serial': timestamp.stdout}) %}
+{% endif %}
+{#
+ #  Eventually output the zone data
+ #}
+; Hash: {{ _zone['hash'] }} {{ _zone['serial'] }}
+; Zone file for {{ _zone_data['domain'] }}
 ; {{ ansible_managed }}
 
-$ORIGIN {{ bind_zone_name }}.
-$TTL {{ bind_zone_ttl }}
+$ORIGIN {{ _zone_data['domain'] }}.
+$TTL {{ _zone_data['ttl'] }}
 
-{% if bind_zone_name_servers|length > 0 %}
-@ IN SOA {{ bind_zone_name_servers|first }}.{{ bind_zone_name }}. {{ bind_zone_hostmaster_email }}.{{ bind_zone_name }}. (
+{% if _zone_data['mname']|length > 0 %}
+@ IN SOA {{ _zone_data['mname']|first }}.{{ _zone_data['domain'] }}. {{ _zone_data['rname'] }}. (
 {% else %}
-@ IN SOA {{ ansible_hostname }}.{{ bind_zone_name }}. {{ bind_zone_hostmaster_email }}.{{ bind_zone_name }}. (
+@ IN SOA {{ ansible_hostname }}.{{ _zone_data['domain'] }}. {{ _zone_data['rname'] }}. (
 {% endif %}
-  {{ timestamp.stdout }}
-  {{ bind_zone_time_to_refresh }}
-  {{ bind_zone_time_to_retry }}
-  {{ bind_zone_time_to_expire }}
-  {{ bind_zone_minimum_ttl }} )
+  {{ _zone['serial'] }}
+  {{ _zone_data['refresh'] }}
+  {{ _zone_data['retry'] }}
+  {{ _zone_data['expire'] }}
+  {{ _zone_data['minimum'] }} )
 
-{% if bind_zone_name_servers|length > 0 %}
-{% for ns in bind_zone_name_servers %}
-                     IN  NS     {{ ns }}.{{ bind_zone_name }}.
+{% if _zone_data['mname']|length > 0 %}
+{% for ns in _zone_data['mname'] %}
+                     IN  NS     {{ ns }}.{{ _zone_data['domain'] }}.
 {% endfor %}
 {% else %}
-                     IN  NS     {{ ansible_hostname }}.{{ bind_zone_name }}.
+                     IN  NS     {{ ansible_hostname }}.{{ _zone_data['domain'] }}.
 {% endif %}
-{% for ns in bind_other_name_servers %}
+{% for ns in _zone_data['aname'] %}
                      IN  NS     {{ ns }}.
 {% endfor %}
 
-{% for mail in bind_zone_mail_servers %}
-{% if loop.first %}@{% else %} {% endif %}                    IN  MX     {{ mail.preference}}  {{ mail.name }}.{{ bind_zone_name }}.
+{% for mail in _zone_data['mail'] %}
+{% if loop.first %}@{% else %} {% endif %}                    IN  MX     {{ mail.preference}}  {{ mail.name }}.{{ _zone_data['domain'] }}.
 {% endfor %}
 
-{% if bind_zone_hosts|length > 0 %}
-{% for host in bind_zone_hosts %}
+{% if _zone_data['hosts']|length > 0 %}
+{% for host in _zone_data['hosts'] %}
 {% if host.ip is defined %}
 {% if host.ip is string %}
 {{ host.name.ljust(20) }} IN  A      {{ host.ip }}
@@ -59,10 +93,10 @@ $TTL {{ bind_zone_ttl }}
 {% else %}
 {{ ansible_hostname.ljust(20) }} IN A     {{ ansible_default_ipv4.address }}
 {% endif %}
-{% for service in bind_zone_services %}
+{% for service in _zone_data['services'] %}
 {{ service.name.ljust(20) }} IN  SRV    {{ service.priority|default('0') }} {{ service.weight|default('0') }} {{ service.port }} {{ service.target }}
 {% endfor %}
-{% for text in bind_zone_text %}
+{% for text in _zone_data['text'] %}
 {{ text.name.ljust(20) }} IN  TXT    "{{ text.text }}"
 {% endfor %}
 {# vim: ft=text

--- a/templates/reverse_zone.j2
+++ b/templates/reverse_zone.j2
@@ -1,51 +1,87 @@
-; Reverse zone file for {{ bind_zone_name }}
+{#
+ #  First create a dict holding the entire zone information and create a hash
+ #  from it, that it can be compared with subsequent task executions. In this
+ #  way the serial will only be updated if there are some content changes.
+ #}
+{% set _zone_data = {} %}
+{% set _ = _zone_data.update({'ttl': bind_zone_ttl}) %}
+{% set _ = _zone_data.update({'domain': bind_zone_name }) %}
+{% set _ = _zone_data.update({'mname': bind_zone_name_servers}) %}
+{% set _ = _zone_data.update({'aname': bind_other_name_servers}) %}
+{% set _ = _zone_data.update({'rname': (( bind_zone_hostmaster_email)) + ('' if (bind_zone_hostmaster_email | search('\.')) else ('.' + _zone_data['domain']))}) %}
+{% set _ = _zone_data.update({'refresh': bind_zone_time_to_refresh}) %}
+{% set _ = _zone_data.update({'retry': bind_zone_time_to_retry}) %}
+{% set _ = _zone_data.update({'expire': bind_zone_time_to_expire}) %}
+{% set _ = _zone_data.update({'minimum': bind_zone_minimum_ttl}) %}
+{% set _ = _zone_data.update({'hosts': bind_zone_hosts }) %}
+{% set _ = _zone_data.update({'revip': ('.'.join(item.replace(item+'.','').split('.')[::-1])) }) %}
+{#
+ #  Compare the zone file hash with the current zone data hash and set serial
+ #  accordingly
+ #}
+{% set _zone = {'hash': _zone_data | string | hash('md5')} %}
+{% for _result in reverse_hashes.results %}
+{%   if (item in _result.item ) %}
+{%     set _hash_serial = _result.stdout.split(' ')[2:] %}
+{%     if _hash_serial and _hash_serial[0] == _zone['hash'] %}
+{%       set _ = _zone.update({'serial': _hash_serial[1]}) %}
+{%     else %}
+{%       set _ = _zone.update({'serial': timestamp.stdout}) %}
+{%     endif %}
+{%   endif %}
+{% endfor %}
+{#
+ #  Eventually output the zone data
+ #}
+; Hash: {{ _zone['hash'] }} {{ _zone['serial'] }}
+; Reverse zone file for {{ _zone_data['domain'] }}
 ; {{ ansible_managed }}
 ; vi: ft=bindzone
 
-$TTL {{ bind_zone_ttl }}
+$TTL {{ _zone_data['ttl'] }}
 $ORIGIN {{ ('.'.join(item.replace(item+'.','').split('.')[::-1])) }}.in-addr.arpa.
 
-{% if bind_zone_name_servers|length > 0 %}
-@ IN SOA {{ bind_zone_name_servers|first }}.{{ bind_zone_name }}. {{ bind_zone_hostmaster_email }}.{{ bind_zone_name }}. (
+{% if _zone_data['mname']|length > 0 %}
+@ IN SOA {{ _zone_data['mname']|first }}.{{ _zone_data['domain'] }}. {{ _zone_data['rname'] }}. (
 {% else %}
-@ IN SOA {{ ansible_hostname }}.{{ bind_zone_name }}. {{ bind_zone_hostmaster_email }}.{{ bind_zone_name }}. (
+@ IN SOA {{ ansible_hostname }}.{{ _zone_data['domain'] }}. {{ _zone_data['rname'] }}. (
 {% endif %}
-  {{ timestamp.stdout }}
-  {{ bind_zone_time_to_refresh }}
-  {{ bind_zone_time_to_retry }}
-  {{ bind_zone_time_to_expire }}
-  {{ bind_zone_minimum_ttl }} )
+  {{ _zone['serial'] }}
+  {{ _zone_data['refresh'] }}
+  {{ _zone_data['retry'] }}
+  {{ _zone_data['expire'] }}
+  {{ _zone_data['minimum'] }} )
 
-{% if bind_zone_name_servers|length > 0 %}
-{% for ns in bind_zone_name_servers %}
-                 IN  NS   {{ ns }}.{{ bind_zone_name }}.
+{% if _zone_data['mname']|length > 0 %}
+{% for ns in _zone_data['mname'] %}
+                 IN  NS   {{ ns }}.{{ _zone_data['domain'] }}.
 {% endfor %}
 {% else %}
-                 IN  NS   {{ ansible_hostname }}.{{ bind_zone_name }}.
+                 IN  NS   {{ ansible_hostname }}.{{ _zone_data['domain'] }}.
 {% endif %}
-{% for ns in bind_other_name_servers %}
+{% for ns in _zone_data['aname'] %}
                  IN  NS   {{ ns }}.
 {% endfor %}
 
-{% if bind_zone_hosts|length > 1 %}
-{% for host in bind_zone_hosts %}
+{% if _zone_data['hosts']|length > 1 %}
+{% for host in _zone_data['hosts'] %}
 {% if host.ip is defined %}
 {% if host.ip == item %}
-@                IN  PTR  {{ host.name }}.{{ bind_zone_name }}.
+@                IN  PTR  {{ host.name }}.{{ _zone_data['domain'] }}.
 {% else %}
 {% if host.ip is string and host.ip.startswith(item) %}
 {% if host.name == '@' %}
-{{ ('.'.join(host.ip.replace(item+'.','').split('.')[::-1])).ljust(16) }} IN  PTR  {{ bind_zone_name }}.
+{{ ('.'.join(host.ip.replace(item+'.','').split('.')[::-1])).ljust(16) }} IN  PTR  {{ _zone_data['domain'] }}.
 {% else %}
-{{ ('.'.join(host.ip.replace(item+'.','').split('.')[::-1])).ljust(16) }} IN  PTR  {{ host.name }}.{{ bind_zone_name }}.
+{{ ('.'.join(host.ip.replace(item+'.','').split('.')[::-1])).ljust(16) }} IN  PTR  {{ host.name }}.{{ _zone_data['domain'] }}.
 {% endif %}
 {% else %}
 {% for ip in host.ip %}
 {% if ip.startswith(item) %}
-{{ ('.'.join(ip.replace(item+'.','').split('.')[::-1])).ljust(16) }} IN  PTR  {{ bind_zone_name }}.
+{{ ('.'.join(ip.replace(item+'.','').split('.')[::-1])).ljust(16) }} IN  PTR  {{ _zone_data['domain'] }}.
 {% if host.name == '@' %}
 {% else %}
-{{ ('.'.join(ip.replace(item+'.','').split('.')[::-1])).ljust(16) }} IN  PTR  {{ host.name }}.{{ bind_zone_name }}.
+{{ ('.'.join(ip.replace(item+'.','').split('.')[::-1])).ljust(16) }} IN  PTR  {{ host.name }}.{{ _zone_data['domain'] }}.
 {% endif %}
 {% endif %}
 {% endfor %}
@@ -54,7 +90,7 @@ $ORIGIN {{ ('.'.join(item.replace(item+'.','').split('.')[::-1])) }}.in-addr.arp
 {% endif %}
 {% endfor %}
 {% else %}
-{{ ('.'.join(ansible_default_ipv4.address.replace(item+'.','').split('.')[::-1])).ljust(16) }} IN  PTR  {{ ansible_hostname }}.{{ bind_zone_name }}.
+{{ ('.'.join(ansible_default_ipv4.address.replace(item+'.','').split('.')[::-1])).ljust(16) }} IN  PTR  {{ ansible_hostname }}.{{ _zone_data['domain'] }}.
 {% endif %}
 {# vim: ft=text
 #}

--- a/templates/reverse_zone.j2
+++ b/templates/reverse_zone.j2
@@ -13,7 +13,7 @@
 {% set _ = _zone_data.update({'retry': bind_zone_time_to_retry}) %}
 {% set _ = _zone_data.update({'expire': bind_zone_time_to_expire}) %}
 {% set _ = _zone_data.update({'minimum': bind_zone_minimum_ttl}) %}
-{% set _ = _zone_data.update({'hosts': bind_zone_hosts }) %}
+{% set _ = _zone_data.update({'hosts': bind_zone_hosts | selectattr('ip', 'search', '^'+item) | list }) %} 
 {% set _ = _zone_data.update({'revip': ('.'.join(item.replace(item+'.','').split('.')[::-1])) }) %}
 {#
  #  Compare the zone file hash with the current zone data hash and set serial
@@ -63,7 +63,7 @@ $ORIGIN {{ ('.'.join(item.replace(item+'.','').split('.')[::-1])) }}.in-addr.arp
                  IN  NS   {{ ns }}.
 {% endfor %}
 
-{% if _zone_data['hosts']|length > 1 %}
+{% if _zone_data['hosts']|length > 0 %}
 {% for host in _zone_data['hosts'] %}
 {% if host.ip is defined %}
 {% if host.ip == item %}

--- a/templates/reverse_zone_ipv6.j2
+++ b/templates/reverse_zone_ipv6.j2
@@ -1,51 +1,87 @@
-; Reverse zone file for {{ bind_zone_name }}
+{#
+ #  First create a dict holding the entire zone information and create a hash
+ #  from it, that it can be compared with subsequent task executions. In this
+ #  way the serial will only be updated if there are some content changes.
+ #}
+{% set _zone_data = {} %}
+{% set _ = _zone_data.update({'ttl': bind_zone_ttl}) %}
+{% set _ = _zone_data.update({'domain': bind_zone_name }) %}
+{% set _ = _zone_data.update({'mname': bind_zone_name_servers}) %}
+{% set _ = _zone_data.update({'aname': bind_other_name_servers}) %}
+{% set _ = _zone_data.update({'rname': (( bind_zone_hostmaster_email)) + ('' if (bind_zone_hostmaster_email | search('\.')) else ('.' + _zone_data['domain']))}) %}
+{% set _ = _zone_data.update({'refresh': bind_zone_time_to_refresh}) %}
+{% set _ = _zone_data.update({'retry': bind_zone_time_to_retry}) %}
+{% set _ = _zone_data.update({'expire': bind_zone_time_to_expire}) %}
+{% set _ = _zone_data.update({'minimum': bind_zone_minimum_ttl}) %}
+{% set _ = _zone_data.update({'hosts': bind_zone_hosts }) %}
+{% set _ = _zone_data.update({'revip': (item | ipaddr('revdns'))[-(9+(item|regex_replace('^.*/','')|int)//2):] }) %}
+{#
+ #  Compare the zone file hash with the current zone data hash and set serial
+ #  accordingly
+ #}
+{% set _zone = {'hash': _zone_data | string | hash('md5')} %}
+{% for _result in reverse_hashes_ipv6.results %}
+{%   if (item in _result.item ) %}
+{%     set _hash_serial = _result.stdout.split(' ')[2:] %}
+{%     if _hash_serial and _hash_serial[0] == _zone['hash'] %}
+{%       set _ = _zone.update({'serial': _hash_serial[1]}) %}
+{%     else %}
+{%       set _ = _zone.update({'serial': timestamp.stdout}) %}
+{%     endif %}
+{%   endif %}
+{% endfor %}
+{#
+ #  Eventually output the zone data
+ #}
+; Hash: {{ _zone['hash'] }} {{ _zone['serial'] }}
+; Reverse zone file for {{ _zone_data['domain'] }}
 ; {{ ansible_managed }}
 ; vi: ft=bindzone
 
-$TTL {{ bind_zone_ttl }}
+$TTL {{ _zone_data['ttl'] }}
 $ORIGIN {{ (item | ipaddr('revdns'))[-(9+(item|regex_replace('^.*/','')|int)//2):] }}
 
-{% if bind_zone_name_servers|length > 0 %}
-@ IN SOA {{ bind_zone_name_servers|first }}.{{ bind_zone_name }}. {{ bind_zone_hostmaster_email }}.{{ bind_zone_name }}. (
+{% if _zone_data['mname']|length > 0 %}
+@ IN SOA {{ _zone_data['mname']|first }}.{{ _zone_data['domain'] }}. {{ _zone_data['rname'] }}. (
 {% else %}
-@ IN SOA {{ ansible_hostname }}.{{ bind_zone_name }}. {{ bind_zone_hostmaster_email }}.{{ bind_zone_name }}. (
+@ IN SOA {{ ansible_hostname }}.{{ _zone_data['domain'] }}. {{ _zone_data['rname'] }}. (
 {% endif %}
-  {{ timestamp.stdout }}
-  {{ bind_zone_time_to_refresh }}
-  {{ bind_zone_time_to_retry }}
-  {{ bind_zone_time_to_expire }}
-  {{ bind_zone_minimum_ttl }} )
+  {{ _zone['serial'] }}
+  {{ _zone_data['refresh'] }}
+  {{ _zone_data['retry'] }}
+  {{ _zone_data['expire'] }}
+  {{ _zone_data['minimum'] }} )
 
-{% if bind_zone_name_servers|length > 0 %}
-{% for ns in bind_zone_name_servers %}
-                 IN  NS   {{ ns }}.{{ bind_zone_name }}.
+{% if _zone_data['mname']|length > 0 %}
+{% for ns in _zone_data['mname'] %}
+                 IN  NS   {{ ns }}.{{ _zone_data['domain'] }}.
 {% endfor %}
 {% else %}
-                 IN  NS   {{ ansible_hostname }}.{{ bind_zone_name }}.
+                 IN  NS   {{ ansible_hostname }}.{{ _zone_data['domain'] }}.
 {% endif %}
-{% for ns in bind_other_name_servers %}
+{% for ns in _zone_data['aname'] %}
                  IN  NS   {{ ns }}.
 {% endfor %}
 
-{% if bind_zone_hosts|length > 1 %}
-{% for host in bind_zone_hosts %}
+{% if _zone_data['hosts']|length > 1 %}
+{% for host in _zone_data['hosts'] %}
 {% if host.ipv6 is defined %}
 {% if host.ipv6 == item %}
-@                IN  PTR  {{ host.name }}.{{ bind_zone_name }}.
+@                IN  PTR  {{ host.name }}.{{ _zone_data['domain'] }}.
 {% else %}
 {% if host.ipv6 is string and host.ipv6.startswith(item|regex_replace('/.*$','')) %}
 {% if host.name == '@' %}
-{{ host.ipv6 | ipaddr('revdns') }} IN  PTR  {{ bind_zone_name }}.
+{{ host.ipv6 | ipaddr('revdns') }} IN  PTR  {{ _zone_data['domain'] }}.
 {% else %}
-{{ host.ipv6 | ipaddr('revdns') }} IN  PTR  {{ host.name }}.{{ bind_zone_name }}.
+{{ host.ipv6 | ipaddr('revdns') }} IN  PTR  {{ host.name }}.{{ _zone_data['domain'] }}.
 {% endif %}
 {% else %}
 {% for ip in host.ipv6 %}
 {% if ip.startswith(item|regex_replace('/.*$','')) %}
-{{ ip | ipaddr('revdns') }} IN  PTR  {{ bind_zone_name }}.
+{{ ip | ipaddr('revdns') }} IN  PTR  {{ _zone_data['domain'] }}.
 {% if host.name == '@' %}
 {% else %}
-{{ ip | ipaddr('revdns') }} IN  PTR  {{ host.name }}.{{ bind_zone_name }}.
+{{ ip | ipaddr('revdns') }} IN  PTR  {{ host.name }}.{{ _zone_data['domain'] }}.
 {% endif %}
 {% endif %}
 {% endfor %}
@@ -54,7 +90,7 @@ $ORIGIN {{ (item | ipaddr('revdns'))[-(9+(item|regex_replace('^.*/','')|int)//2)
 {% endif %}
 {% endfor %}
 {% else %}
-{{ ansible_default_ipv6.address | ipaddr('revdns') }} IN  PTR  {{ ansible_hostname }}.{{ bind_zone_name }}.
+{{ ansible_default_ipv6.address | ipaddr('revdns') }} IN  PTR  {{ ansible_hostname }}.{{ _zone_data['domain'] }}.
 {% endif %}
 {# vim: ft=text
 #}


### PR DESCRIPTION
I have made some changes to the zonefile templates to make them idempotent during each execution.

They will only get re-generated if the data in them genuinely changes, rather than every time, because of the serial.

Was created from an idea noted in the following article:
https://linuxmonk.ch/wordpress/index.php/2016/managing-dns-zones-with-ansible/