### PR TITLE
Bugfix and additional support for zone type 'forward'

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,3 +59,7 @@ bind_zone_mail_servers: []
 bind_zone_name_servers: []
 bind_zone_services: []
 bind_zone_text: []
+
+#Forwarded zone lookup
+forward_zone_name: []
+forward_zone_forwarders: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,12 +13,23 @@
   assert:
     that: bind_zone_master_server_ip is defined
 
-- name: Install BIND
-  package:
+- name: Install BIND on Debian
+  apt:
     pkg: "{{ item }}"
     state: installed
+    update_cache: yes
   with_items: "{{ bind_packages }}"
   tags: bind
+  when: ansible_os_family == 'Debian'
+
+- name: Install BIND on RedHat
+  yum:
+    pkg: "{{ item }}"
+    state: installed
+    update_cache: yes
+  with_items: "{{ bind_packages }}"
+  tags: bind
+  when: ansible_os_family == 'RedHat'
 
 - name: Ensure runtime directories referenced in config exist
   file:
@@ -71,4 +82,3 @@
     state: started
     enabled: yes
   tags: bind
-

--- a/templates/master_etc_named.conf.j2
+++ b/templates/master_etc_named.conf.j2
@@ -64,6 +64,13 @@ zone "{{ bind_zone_name }}" IN {
   allow-update { {{ bind_allow_update|join(';') }}; };
 };
 
+{% if forward_zone_name is defined %}
+zone "{{ forward_zone_name }}" IN {
+  type forward;
+  forwarders { {{ forward_zone_forwarders }}; };
+};
+{% endif %}
+
 {% if bind_zone_networks is defined %}
 {% for network in bind_zone_networks %}
 zone "{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr.arpa" IN {

--- a/templates/slave_etc_named.conf.j2
+++ b/templates/slave_etc_named.conf.j2
@@ -60,6 +60,13 @@ zone "{{ bind_zone_name }}" IN {
   file "slaves/{{ bind_zone_name }}";
 };
 
+{% if forward_zone_name is defined %}
+zone "{{ forward_zone_name }}" IN {
+  type forward;
+  forwarders { {{ forward_zone_forwarders }}; };
+};
+{% endif %}
+
 {% if bind_zone_networks is defined %}
 {% for network in bind_zone_networks %}
 zone "{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr.arpa" IN {
@@ -79,4 +86,3 @@ zone "{{ (network | ipaddr('revdns'))[-(9+(network|regex_replace('^.*/','')|int)
 };
 {% endfor %}
 {% endif %}
-


### PR DESCRIPTION
Fixes a bug with installation on ubuntu where it fails due to not updating the apt cache. This implements support for apt and yum installation.

Also adds support for a domain forwarder, so that lookups for a specific domain can be forwarded to upstream servers.