### PR TITLE
Make DNSSEC options configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Variables are not required, unless specified.
 | `bind_other_name_servers`      | `[]`                             | A list of nameservers outside of the domain. For each one, an NS record will be created.                         |
 | `bind_recursion`               | `false`                          | Determines whether requests for which the DNS server is not authoritative should be forwarded†.                  |
 | `bind_rrset_order`             | `random`                         | Defines order for DNS round robin (either `random` or `cyclic`)                                                  |
+| `bind_dnssec_enable`           | `true`                           | Is DNSSEC enabled                                                                                                |
+| `bind_dnssec_validation`       | `true`                           | Is DNSSEC validation enabled                                                                                     |
 | `bind_zone_also_notify`        | -                                | A list of servers that will receive a notification when the master zone file is reloaded.                        |
 | `bind_zone_hostmaster_email`   | `hostmaster`                     | The e-mail address of the system administrator                                                                   |
 | `bind_zone_hosts`              | `[]`                             | Host definitions. See below this table for examples.                                                             |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,6 +44,10 @@ bind_forwarders: []
 # DNS round robin order (random or cyclic)
 bind_rrset_order: "random"
 
+# DNSSEC configuration
+bind_dnssec_enable: true
+bind_dnssec_validation: true
+
 # SOA information
 bind_zone_hostmaster_email: "hostmaster"
 bind_zone_ttl: "1W"

--- a/templates/master_etc_named.conf.j2
+++ b/templates/master_etc_named.conf.j2
@@ -29,8 +29,8 @@ options {
 
   rrset-order { order {{ bind_rrset_order }}; };
 
-  dnssec-enable yes;
-  dnssec-validation yes;
+  dnssec-enable {{ bind_dnssec_enable }};
+  dnssec-validation {{ bind_dnssec_validation }};
   dnssec-lookaside auto;
 
   /* Path to ISC DLV key */

--- a/templates/slave_etc_named.conf.j2
+++ b/templates/slave_etc_named.conf.j2
@@ -29,8 +29,8 @@ options {
 
   rrset-order { order {{ bind_rrset_order }}; };
 
-  dnssec-enable yes;
-  dnssec-validation yes;
+  dnssec-enable {{ bind_dnssec_enable }};
+  dnssec-validation {{ bind_dnssec_validation }};
   dnssec-lookaside auto;
 
   /* Path to ISC DLV key */


### PR DESCRIPTION
Hi Bert,

This is a little PR that allows DNSSEC to be disabled.
The use case is to setup a DNS server that acts a forwarder to AWS VPC private zone, which does not supports DNSSEC (see https://aws.amazon.com/premiumsupport/knowledge-center/r53-private-ubuntu/)

Hope this helps,
Guillaume