### PR TITLE
Allow multi-line ansible_managed comment

### DIFF
--- a/templates/bind_zone.j2
+++ b/templates/bind_zone.j2
@@ -34,7 +34,7 @@
  #}
 ; Hash: {{ _zone['hash'] }} {{ _zone['serial'] }}
 ; Zone file for {{ _zone_data['domain'] }}
-; {{ ansible_managed }}
+{{ ansible_managed | comment(decoration='; ') }}
 
 $ORIGIN {{ _zone_data['domain'] }}.
 $TTL {{ _zone_data['ttl'] }}

--- a/templates/master_etc_named.conf.j2
+++ b/templates/master_etc_named.conf.j2
@@ -1,7 +1,7 @@
 //
 // named.conf
 //
-// {{ ansible_managed }}
+// {{ ansible_managed | comment('c') }}
 //
 {% for acl in bind_acls %}
 acl "{{ acl.name }}" {

--- a/templates/reverse_zone.j2
+++ b/templates/reverse_zone.j2
@@ -35,7 +35,7 @@
  #}
 ; Hash: {{ _zone['hash'] }} {{ _zone['serial'] }}
 ; Reverse zone file for {{ _zone_data['domain'] }}
-; {{ ansible_managed }}
+{{ ansible_managed | comment(decoration='; ') }}
 ; vi: ft=bindzone
 
 $TTL {{ _zone_data['ttl'] }}

--- a/templates/reverse_zone_ipv6.j2
+++ b/templates/reverse_zone_ipv6.j2
@@ -35,7 +35,7 @@
  #}
 ; Hash: {{ _zone['hash'] }} {{ _zone['serial'] }}
 ; Reverse zone file for {{ _zone_data['domain'] }}
-; {{ ansible_managed }}
+{{ ansible_managed | comment(decoraton='; ') }}
 ; vi: ft=bindzone
 
 $TTL {{ _zone_data['ttl'] }}

--- a/templates/slave_etc_named.conf.j2
+++ b/templates/slave_etc_named.conf.j2
@@ -1,7 +1,7 @@
 //
 // named.conf
 //
-// {{ ansible_managed }}
+{{ ansible_managed | comment('c') }}
 //
 {% for acl in bind_acls %}
 acl "{{ acl.name }}" {


### PR DESCRIPTION
When `{{ ansible_managed }}` string is multi-line, the template files end up having syntax errors since the multi-lined `{{ ansible_managed }}` does not get properly commented. This PR is to fix the issue.