### PR TITLE
Create serial as UTC UNIX time

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,8 +32,8 @@
     - "{{ bind_dir }}/data"
   tags: bind
 
-- name: Create serial, based on last two digits of year, month, day, and hour
-  command: date +%y%m%d%H
+- name: Create serial, based on UTC UNIX time
+  command: date -u +%s
   register: timestamp
   changed_when: false
   run_once: true


### PR DESCRIPTION
This changes the BIND zone serial to use UTC UNIX time, allowing updates to the records therein to happen as frequently as once per second while still propagating those updates to slave servers.

BIND's serial is any positive integer, modulo 2^32. UNIX time is 2^32 maximum (at least until we try to solve the 2038 problem), so this is safe from a bounds standpoint (and almost certainly thereafter with the modulo).

This is also safe for things currently in production so long as it's after Wed Feb 21 06:12:03 UTC 1973 (the maximum UNIX timestamp equivalent value of the current '+%y%m%d%H' timestamp).