### PR TITLE
Small tidy ups, tweaks, and config rationalisation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,21 +30,17 @@ Variables are not required, unless specified.
 | :---                           | :---                             | :---                                                                                                                     |
 | `bind_acls`                    | `[]`                             | A list of ACL definitions, which are dicts with fields `name` and `match_list`. See below for an example.                |
 | `bind_allow_query`             | `['localhost']`                  | A list of hosts that are allowed to query this DNS server. Set to ['any'] to allow all hosts                             |
-| `bind_allow_update`            | `['none']`                       | A list of hosts that are allowed to dynamically update this DNS server.                                                  |
 | `bind_check_names`             | `[]`                             | Check host names for compliance with RFC 952 and RFC 1123 and take the defined actioni (e.g. `warn`, `ignore`, `fail`).  |
 | `bind_forwarders`              | `[]`                             | A list of name servers to forward DNS requests to.                                                                       |
 | `bind_forward_only`            | `false`                          | If `true`, BIND is set up as a caching name server                                                                       |
 | `bind_listen_ipv4`             | `['127.0.0.1']`                  | A list of the IPv4 address of the network interface(s) to listen on. Set to ['any'] to listen on all interfaces.         |
 | `bind_listen_ipv6`             | `['::1']`                        | A list of the IPv6 address of the network interface(s) to listen on                                                      |
 | `bind_log`                     | `data/named.run`                 | Path to the log file                                                                                                     |
-| `bind_other_name_servers`      | `[]`                             | A list of nameservers outside of the domain. For each one, an NS record will be created.                                 |
 | `bind_recursion`               | `false`                          | Determines whether requests for which the DNS server is not authoritative should be forwarded†.                          |
 | `bind_allow_recursion`         | `['any']`                        | Similar to bind_allow_query, this option applies to recursive queries.                                                   |
 | `bind_rrset_order`             | `random`                         | Defines order for DNS round robin (either `random` or `cyclic`)                                                          |
 | `bind_dnssec_enable`           | `true`                           | Is DNSSEC enabled                                                                                                        |
 | `bind_dnssec_validation`       | `true`                           | Is DNSSEC validation enabled                                                                                             |
-| `bind_zone_also_notify`        | -                                | A list of servers that will receive a notification when the master zone file is reloaded.                                |
-| `bind_zone_hostmaster_email`   | `hostmaster`                     | The e-mail address of the system administrator                                                                           |
 | `bind_zone_master_server_ip`   | -                                | **(Required)** The IP address of the master DNS server.                                                                  |
 | `bind_zone_minimum_ttl`        | `1D`                             | Minimum TTL field in the SOA record.                                                                                     |
 | `bind_zone_domains`            | n/a                              | A list of domains to configure, with a seperate dict for each domain, with relevant details                              |
@@ -53,10 +49,13 @@ Variables are not required, unless specified.
 | `- ipv6_networks`              | `[]`                             | A list of the IPv6 networks that are part of the domain, in CIDR notation (e.g. 2001:db8::/48)                           |
 | `- name_servers`               | `[ansible_hostname]`             | A list of the DNS servers for this domain.                                                                               |
 | `- other_name_servers`         | `[]`                             | A list of the DNS servers outside of this domain.                                                                        |
+| `- hostmaster_email`           | `hostmaster`                     | The e-mail address of the system administrator for the zone                                                              |
+| `- allow_update`               | `['none']`                       | A list of hosts that are allowed to dynamically update this DNS zone.                                                    |
 | `- services`                   | `[]`                             | A list of services to be advertized by SRV records                                                                       |
 | `- text`                       | `[]`                             | A list of dicts with fields `name` and `text`, specifying TXT records. `text` can be a list or string.                   |
 | `- hosts`                      | `[]`                             | Host definitions. See below this table for examples.                                                                     |
 | `- delegate`                   | `[]`                             | Zone delegation. See below this table for examples.                                                                      |
+| `- also_notify`                | -                                | A list of servers that will receive a notification when the master zone file is reloaded.                                |
 | `- mail_servers`               | `[{name: mail, preference: 10}]` | A list of dicts (with fields `name` and `preference`) specifying the mail servers for this domain.                       |
 | `bind_zone_time_to_expire`     | `1W`                             | Time to expire field in the SOA record.                                                                                  |
 | `bind_zone_time_to_refresh`    | `1D`                             | Time to refresh field in the SOA record.                                                                                 |

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Variables are not required, unless specified.
 | `bind_dnssec_enable`           | `true`                           | Is DNSSEC enabled                                                                                                        |
 | `bind_dnssec_validation`       | `true`                           | Is DNSSEC validation enabled                                                                                             |
 | `bind_zone_master_server_ip`   | -                                | **(Required)** The IP address of the master DNS server.                                                                  |
-| `bind_zone_minimum_ttl`        | `1D`                             | Minimum TTL field in the SOA record.                                                                                     |
 | `bind_zone_domains`            | n/a                              | A list of domains to configure, with a seperate dict for each domain, with relevant details                              |
 | `- name`                       | `example.com`                    | The domain name                                                                                                          |
 | `- networks`                   | `['10.0.2']`                     | A list of the networks that are part of the domain                                                                       |
@@ -57,6 +56,7 @@ Variables are not required, unless specified.
 | `- delegate`                   | `[]`                             | Zone delegation. See below this table for examples.                                                                      |
 | `- also_notify`                | -                                | A list of servers that will receive a notification when the master zone file is reloaded.                                |
 | `- mail_servers`               | `[{name: mail, preference: 10}]` | A list of dicts (with fields `name` and `preference`) specifying the mail servers for this domain.                       |
+| `bind_zone_minimum_ttl`        | `1D`                             | Minimum TTL field in the SOA record.                                                                                     |
 | `bind_zone_time_to_expire`     | `1W`                             | Time to expire field in the SOA record.                                                                                  |
 | `bind_zone_time_to_refresh`    | `1D`                             | Time to refresh field in the SOA record.                                                                                 |
 | `bind_zone_time_to_retry`      | `1H`                             | Time to retry field in the SOA record.                                                                                   |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,11 +5,9 @@ bind_log: "data/named.run"
 
 bind_zone_domains:
   - name: "example.com"
+    hostmaster_email: "hostmaster"
     networks:
       - "10.0.2"
-
-# List of servers to be notified when the master zone is reloaded.
-bind_zone_also_notify: []
 
 # List of acls.
 bind_acls: []
@@ -26,10 +24,6 @@ bind_listen_ipv6:
 # List of hosts that are allowed to query this DNS server.
 bind_allow_query:
   - "localhost"
-
-# List of hosts that are allowed to dynamically update this DNS server
-bind_allow_update:
-  - "none"
 
 # Determines whether recursion should be allowed. Typically, an authoritative
 # name server should have recursion turned OFF.
@@ -51,12 +45,8 @@ bind_dnssec_enable: true
 bind_dnssec_validation: true
 
 # SOA information
-bind_zone_hostmaster_email: "hostmaster"
 bind_zone_ttl: "1W"
 bind_zone_time_to_refresh: "1D"
 bind_zone_time_to_retry: "1H"
 bind_zone_time_to_expire: "1W"
 bind_zone_minimum_ttl: "1D"
-
-# Zone Resource Records
-bind_other_name_servers: []

--- a/templates/bind_zone.j2
+++ b/templates/bind_zone.j2
@@ -5,19 +5,23 @@
  #}
 {% set _zone_data = {} %}
 {% set _ = _zone_data.update({'ttl': bind_zone_ttl}) %}
-{% set _ = _zone_data.update({'domain': item.name }) %}
-{% set _ = _zone_data.update({'mname': item.name_servers|default([]) }) %}
-{% set _ = _zone_data.update({'aname': item.other_name_servers|default([]) }) %}
-{% set _ = _zone_data.update({'mail': item.mail_servers|default([]) }) %}
-{% set _ = _zone_data.update({'rname': (( bind_zone_hostmaster_email)) + ('' if (bind_zone_hostmaster_email | search('\.')) else ('.' + _zone_data['domain']))}) %}
+{% set _ = _zone_data.update({'domain': item.name}) %}
+{% set _ = _zone_data.update({'mname': item.name_servers|default([])}) %}
+{% set _ = _zone_data.update({'aname': item.other_name_servers|default([])}) %}
+{% set _ = _zone_data.update({'mail': item.mail_servers|default([])}) %}
+{% if item.hostmaster_email is defined %}
+{% set _ = _zone_data.update({'rname': (( item.hostmaster_email )) + ('' if (item.hostmaster_email is search('\.')) else ('.' + _zone_data['domain']))}) %}
+{% else %}
+{% set _ = _zone_data.update({'rname': 'hostmaster.' + _zone_data['domain']}) %}
+{% endif %}
 {% set _ = _zone_data.update({'refresh': bind_zone_time_to_refresh}) %}
 {% set _ = _zone_data.update({'retry': bind_zone_time_to_retry}) %}
 {% set _ = _zone_data.update({'expire': bind_zone_time_to_expire}) %}
 {% set _ = _zone_data.update({'minimum': bind_zone_minimum_ttl}) %}
-{% set _ = _zone_data.update({'hosts': item.hosts|default([]) }) %}
-{% set _ = _zone_data.update({'delegate': item.delegate|default([]) }) %}
-{% set _ = _zone_data.update({'services': item.services|default([]) }) %}
-{% set _ = _zone_data.update({'text': item.text|default([]) }) %}
+{% set _ = _zone_data.update({'hosts': item.hosts|default([])}) %}
+{% set _ = _zone_data.update({'delegate': item.delegate|default([])}) %}
+{% set _ = _zone_data.update({'services': item.services|default([])}) %}
+{% set _ = _zone_data.update({'text': item.text|default([])}) %}
 {#
  #  Compare the zone file hash with the current zone data hash and set serial
  #  accordingly

--- a/templates/master_etc_named.conf.j2
+++ b/templates/master_etc_named.conf.j2
@@ -28,7 +28,7 @@ options {
   recursion {% if bind_recursion %}yes{% else %}no{% endif %};
   {% if bind_recursion %}allow-recursion { {{ bind_allow_recursion|join('; ') }}; };
   {% endif %}
-  {% if bind_forwarders|length > 0 %}forwarders { {{ bind_forwarders|join('; ') }}; };{% endif %}
+{% if bind_forwarders|length > 0 %}forwarders { {{ bind_forwarders|join('; ') }}; };{% endif %}
   {% if bind_forward_only %}forward only;{% endif %}
 
   rrset-order { order {{ bind_rrset_order }}; };
@@ -64,10 +64,14 @@ zone "{{ bind_zone.name }}" IN {
   type master;
   file "{{ bind_zone.name }}";
   notify yes;
-{% if bind_zone_also_notify|length > 0 %}
-  also-notify  { {{ bind_zone_also_notify|join(';') }}; };
+{% if bind_zone.also_notify is defined %}
+  also-notify  { {{ bind_zone.also_notify|join(';') }}; };
 {% endif %}
-  allow-update { {{ bind_allow_update|join(';') }}; };
+{% if bind_zone.allow_update is defined %}
+  allow-update { {{ bind_zone.allow_update|join(';') }}; };
+{% else %}
+  allow-update { none; };
+{% endif %}
 };
 
 {% if bind_zone.networks is defined %}
@@ -76,10 +80,14 @@ zone "{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr
   type master;
   file "{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr.arpa";
   notify yes;
-{% if bind_zone_also_notify|length > 0 %}
-  also-notify  { {{ bind_zone_also_notify|join(';') }}; };
+{% if bind_zone.also_notify is defined %}
+  also-notify  { {{ bind_zone.also_notify|join(';') }}; };
 {% endif %}
-  allow-update { {{ bind_allow_update|join(';') }}; };
+{% if bind_zone.allow_update is defined %}
+  allow-update { {{ bind_zone.allow_update|join(';') }}; };
+{% else %}
+  allow-update { none; };
+{% endif %}
 };
 {% endfor %}
 {% endif %}
@@ -90,10 +98,14 @@ zone "{{ (network | ipaddr('revdns'))[-(9+(network|regex_replace('^.*/','')|int)
   type master;
   file "{{ (network | ipaddr('revdns'))[-(9+(network|regex_replace('^.*/','')|int)//2):-1] }}";
   notify yes;
-{% if bind_zone_also_notify|length > 0 %}
-  also-notify  { {{ bind_zone_also_notify|join(';') }}; };
+{% if bind_zone.also_notify is defined %}
+  also-notify  { {{ bind_zone.also_notify|join(';') }}; };
 {% endif %}
-  allow-update { {{ bind_allow_update|join(';') }}; };
+{% if bind_zone.allow_update is defined %}
+  allow-update { {{ bind_zone.allow_update|join(';') }}; };
+{% else %}
+  allow-update { none; };
+{% endif %}
 };
 {% endfor %}
 {% endif %}

--- a/templates/reverse_zone.j2
+++ b/templates/reverse_zone.j2
@@ -5,16 +5,20 @@
  #}
 {% set _zone_data = {} %}
 {% set _ = _zone_data.update({'ttl': bind_zone_ttl}) %}
-{% set _ = _zone_data.update({'domain': item.0.name }) %}
+{% set _ = _zone_data.update({'domain': item.0.name}) %}
 {% set _ = _zone_data.update({'mname': item.0.name_servers|default([])}) %}
-{% set _ = _zone_data.update({'aname': bind_other_name_servers}) %}
-{% set _ = _zone_data.update({'rname': (( bind_zone_hostmaster_email)) + ('' if (bind_zone_hostmaster_email | search('\.')) else ('.' + _zone_data['domain']))}) %}
+{% set _ = _zone_data.update({'aname': item.0.other_name_servers|default([])}) %}
+{% if item.0.hostmaster_email is defined %}
+{% set _ = _zone_data.update({'rname': (( item.0.hostmaster_email )) + ('' if (item.0.hostmaster_email is search('\.')) else ('.' + _zone_data['domain']))}) %}
+{% else %}
+{% set _ = _zone_data.update({'rname': 'hostmaster.' + _zone_data['domain']}) %}
+{% endif %}
 {% set _ = _zone_data.update({'refresh': bind_zone_time_to_refresh}) %}
 {% set _ = _zone_data.update({'retry': bind_zone_time_to_retry}) %}
 {% set _ = _zone_data.update({'expire': bind_zone_time_to_expire}) %}
 {% set _ = _zone_data.update({'minimum': bind_zone_minimum_ttl}) %}
-{% set _ = _zone_data.update({'hosts': item.0.hosts|default([]) | selectattr('ip', 'defined') | selectattr('ip', 'string') | selectattr('ip', 'search', '^'+item.1) | list }) %}
-{% set _ = _zone_data.update({'revip': ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }) %}
+{% set _ = _zone_data.update({'hosts': item.0.hosts|default([]) | selectattr('ip', 'defined') | selectattr('ip', 'string') | selectattr('ip', 'search', '^'+item.1) | list}) %}
+{% set _ = _zone_data.update({'revip': ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1]))}) %}
 {#
  #  Compare the zone file hash with the current zone data hash and set serial
  #  accordingly

--- a/templates/reverse_zone_ipv6.j2
+++ b/templates/reverse_zone_ipv6.j2
@@ -5,10 +5,14 @@
  #}
 {% set _zone_data = {} %}
 {% set _ = _zone_data.update({'ttl': bind_zone_ttl}) %}
-{% set _ = _zone_data.update({'domain': item.0.name }) %}
+{% set _ = _zone_data.update({'domain': item.0.name}) %}
 {% set _ = _zone_data.update({'mname': item.0.name_servers|default([])}) %}
-{% set _ = _zone_data.update({'aname': bind_other_name_servers}) %}
-{% set _ = _zone_data.update({'rname': (( bind_zone_hostmaster_email)) + ('' if (bind_zone_hostmaster_email is search('\.')) else ('.' + _zone_data['domain']))}) %}
+{% set _ = _zone_data.update({'aname': item.0.other_name_servers|default([])}) %}
+{% if item.0.hostmaster_email is defined %}
+{% set _ = _zone_data.update({'rname': (( item.0.hostmaster_email )) + ('' if (item.0.hostmaster_email is search('\.')) else ('.' + _zone_data['domain']))}) %}
+{% else %}
+{% set _ = _zone_data.update({'rname': 'hostmaster.' + _zone_data['domain']}) %}
+{% endif %}
 {% set _ = _zone_data.update({'refresh': bind_zone_time_to_refresh}) %}
 {% set _ = _zone_data.update({'retry': bind_zone_time_to_retry}) %}
 {% set _ = _zone_data.update({'expire': bind_zone_time_to_expire}) %}

--- a/templates/slave_etc_named.conf.j2
+++ b/templates/slave_etc_named.conf.j2
@@ -24,7 +24,7 @@ options {
 {% endif %}
 
   recursion {% if bind_recursion %}yes{% else %}no{% endif %};
-  {% if bind_forwarders|length > 0 %}forwarders { {{ bind_forwarders|join('; ') }}; };{% endif %}
+{% if bind_forwarders|length > 0 %}forwarders { {{ bind_forwarders|join('; ') }}; };{% endif %}
   {% if bind_forward_only %}forward only;{% endif %}
 
   rrset-order { order {{ bind_rrset_order }}; };


### PR DESCRIPTION
Noticed that some "global variables" had not been rolled into the templates in all cases for the multi-zone work.  Also pulled in the other "zone specific" configs from their "global" standpoint.   Best to do sooner, whilst people are migrating to the v4.0.0 release, to minimise migration impacts (these changes, are also not backward compatible)