### PR TITLE
Fixes issue with non-existing file when grepping domain

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,7 +41,7 @@
   tags: bind
 
 - name: Read forward zone hashes
-  shell: 'grep "^; Hash:" {{ bind_dir }}/{{ item.name }} || true'
+  shell: 'grep -s "^; Hash:" {{ bind_dir }}/{{ item.name }} || true'
   changed_when: false
   check_mode: false
   register: forward_hashes_temp
@@ -56,7 +56,7 @@
 
 
 - name: Read reverse ipv4 zone hashes
-  shell: "grep \"^; Hash:\" {{ bind_dir }}/{{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr.arpa || true"
+  shell: "grep -s \"^; Hash:\" {{ bind_dir }}/{{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr.arpa || true"
   changed_when: false
   check_mode: false
   register: reverse_hashes_temp
@@ -74,7 +74,7 @@
     - item
 
 - name: Read reverse ipv6 zone hashes
-  shell: "grep \"^; Hash:\" {{bind_dir}}/{{ (item.1 | ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):-1] }} || true"
+  shell: "grep -s \"^; Hash:\" {{bind_dir}}/{{ (item.1 | ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):-1] }} || true"
   changed_when: false
   check_mode: false
   register: reverse_hashes_ipv6_temp


### PR DESCRIPTION
when domain file is not yet created, then grep was complaining and role failed. Tested with ansible 2.4.3 against Ubuntu 14.4