### PR TITLE
add support for DNAME record type

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ bind_zone_domains:
           - www
       - name: priv01
         ip: 10.0.0.1
+      - name: mydomain.net.
+        aliases:
+          - name: sub01
+            type: DNAME
     networks:
       - '192.0.2'
       - '10'
@@ -130,7 +134,7 @@ bind_zone_domains:
 
 ### Hosts
 
-Host names that this DNS server should resolve can be specified in `hosts` as a list of dicts with fields `name`, `ip` and `aliases`
+Host names that this DNS server should resolve can be specified in `hosts` as a list of dicts with fields `name`, `ip` and `aliases` Aliases can be CNAME (default) or DNAME records.
 
 To allow to surf to http://example.com/, set the host name of your web server to `'@'` (must be quoted!). In BIND syntax, `@` indicates the domain name itself.
 

--- a/templates/bind_zone.j2
+++ b/templates/bind_zone.j2
@@ -100,7 +100,7 @@ $TTL {{ _zone_data['ttl'] }}
 {% endif %}
 {% if host.aliases is defined %}
 {% for alias in host.aliases %}
-{{ alias.ljust(20) }} IN  CNAME  {{ host.name }}
+{{ (alias.name|default(alias)).ljust(20) }} IN  {{ alias.type|default('cname')|upper}}  {{ host.name }}
 {% endfor %}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
Introduce optional `type` attribute to `aliases` to allow DNAME records.