### PR TITLE
WIP: Add support for the $GENERATE Directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,7 @@ env:
     - DISTRIBUTION: ubuntu
       VERSION: 18.04
     - DISTRIBUTION: debian
-      VERSION: 8
-    - DISTRIBUTION: debian
       VERSION: 9
-    - DISTRIBUTION: arch
-      VERSION: latest
 
 services:
   - docker

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Variables are not required, unless specified.
 | `bind_acls`                  | `[]`                             | A list of ACL definitions, which are dicts with fields `name` and `match_list`. See below for an example.                   |
 | `bind_allow_query`           | `['localhost']`                  | A list of hosts that are allowed to query this DNS server. Set to ['any'] to allow all hosts                                |
 | `bind_allow_recursion`       | `['any']`                        | Similar to bind_allow_query, this option applies to recursive queries.                                                      |
-| `bind_check_names`           | `[]`                             | Check host names for compliance with RFC 952 and RFC 1123 and take the defined actioni (e.g. `warn`, `ignore`, `fail`).     |
+| `bind_check_names`           | `[]`                             | Check host names for compliance with RFC 952 and RFC 1123 and take the defined action (e.g. `warn`, `ignore`, `fail`).     |
 | `bind_dnssec_enable`         | `true`                           | Is DNSSEC enabled                                                                                                           |
 | `bind_dnssec_validation`     | `true`                           | Is DNSSEC validation enabled                                                                                                |
 | `bind_extra_include_files`   | `[]`                             |                                                                                                                             |
@@ -40,11 +40,15 @@ Variables are not required, unless specified.
 | `bind_listen_ipv4`           | `['127.0.0.1']`                  | A list of the IPv4 address of the network interface(s) to listen on. Set to ['any'] to listen on all interfaces.            |
 | `bind_listen_ipv6`           | `['::1']`                        | A list of the IPv6 address of the network interface(s) to listen on                                                         |
 | `bind_log`                   | `data/named.run`                 | Path to the log file                                                                                                        |
+| `bind_other_logs`            | -                                | A list of logging channels to configure, with a separate dict for each domain, with relevant details                        |
+| `- allow_update`             | `['none']`                       | A list of hosts that are allowed to dynamically update this DNS zone.                                                       |
+| `- also_notify`              | -                                | A list of servers that will receive a notification when the master zone file is reloaded.                                   |
+| `- delegate`                 | `[]`                             | Zone delegation. See below this table for examples.                                                                         |
 | `bind_query_log`             | -                                | When defined (e.g. `data/query.log`), this will turn on the query log                                                       |
 | `bind_recursion`             | `false`                          | Determines whether requests for which the DNS server is not authoritative should be forwarded†.                             |
 | `bind_rrset_order`           | `random`                         | Defines order for DNS round robin (either `random` or `cyclic`)                                                             |
 | `bind_zone_dir`              | -                                | When defined, sets a custom absolute path to the server directory (for zone files, etc.) instead of the default.            |
-| `bind_zone_domains`          | n/a                              | A list of domains to configure, with a seperate dict for each domain, with relevant details                                 |
+| `bind_zone_domains`          | n/a                              | A list of domains to configure, with a separate dict for each domain, with relevant details                                 |
 | `- allow_update`             | `['none']`                       | A list of hosts that are allowed to dynamically update this DNS zone.                                                       |
 | `- also_notify`              | -                                | A list of servers that will receive a notification when the master zone file is reloaded.                                   |
 | `- delegate`                 | `[]`                             | Zone delegation. See below this table for examples.                                                                         |
@@ -56,7 +60,7 @@ Variables are not required, unless specified.
 | `- name`                     | `example.com`                    | The domain name                                                                                                             |
 | `- networks`                 | `['10.0.2']`                     | A list of the networks that are part of the domain                                                                          |
 | `- other_name_servers`       | `[]`                             | A list of the DNS servers outside of this domain.                                                                           |
-| `- services`                 | `[]`                             | A list of services to be advertized by SRV records                                                                          |
+| `- services`                 | `[]`                             | A list of services to be advertised by SRV records                                                                          |
 | `- text`                     | `[]`                             | A list of dicts with fields `name` and `text`, specifying TXT records. `text` can be a list or string.                      |
 | `- naptr`                    | `[]`                             | A list of dicts with fields `name`, `order`, `pref`, `flags`, `service`, `regex` and `replacement` specifying NAPTR records.|
 | `bind_zone_file_mode`        | 0640                             | The file permissions for the main config file (named.conf)                                                                  |
@@ -343,6 +347,7 @@ Pull requests are also very welcome. Please create a topic branch for your propo
 - [Jörg Eichhorn](https://github.com/jeichhorn)
 - [Loic Dachary](http://dachary.org)
 - [Mario Ciccarelli](https://github.com/kartone)
+- [Paulo E. Castro](https://github.com/pecastro)
 - [Peter Janes](https://github.com/peterjanes)
 - [Rafael Bodill](https://github.com/rafi)
 - [Romuald](https://github.com/rds13)

--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ bind_zone_domains:
           - www
       - name: priv01
         ip: 10.0.0.1
+      - name: mydomain.net.
+        aliases:
+          - name: sub01
+            type: DNAME
     networks:
       - '192.0.2'
       - '10'
@@ -133,7 +137,7 @@ bind_zone_domains:
 
 ### Hosts
 
-Host names that this DNS server should resolve can be specified in `hosts` as a list of dicts with fields `name`, `ip`,  `aliases`, `ipv6`, `aliases` and `sshfp`.
+Host names that this DNS server should resolve can be specified in `hosts` as a list of dicts with fields `name`, `ip`,  `aliases` and `sshfp`. Aliases can be CNAME (default) or DNAME records.
 
 To allow to surf to http://example.com/, set the host name of your web server to `'@'` (must be quoted!). In BIND syntax, `@` indicates the domain name itself.
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ bind_zone_domains:
         ip:
           - 192.0.2.2
           - 192.0.2.3
+        sshfp:
+          - "3 1 1262006f9a45bb36b1aa14f45f354b694b77d7c3"
+          - "3 2 e5921564252fe10d2dbafeb243733ed8b1d165b8fa6d5a0e29198e5793f0623b"
         ipv6:
           - 2001:db8::2
           - 2001:db8::3
@@ -130,7 +133,7 @@ bind_zone_domains:
 
 ### Hosts
 
-Host names that this DNS server should resolve can be specified in `hosts` as a list of dicts with fields `name`, `ip` and `aliases`
+Host names that this DNS server should resolve can be specified in `hosts` as a list of dicts with fields `name`, `ip`,  `aliases`, `ipv6`, `aliases` and `sshfp`.
 
 To allow to surf to http://example.com/, set the host name of your web server to `'@'` (must be quoted!). In BIND syntax, `@` indicates the domain name itself.
 
@@ -154,7 +157,7 @@ foo IN NS 192.0.2.1
 
 ### Service records
 
-Service (SRV) records can be added with the services. Tis should be a list of dicts with mandatory fields `name` (service name), `target` (host providing the service), `port` (TCP/UDP port of the service) and optional fields `priority` (default = 0) and `weight` (default = 0).
+Service (SRV) records can be added with the services. This should be a list of dicts with mandatory fields `name` (service name), `target` (host providing the service), `port` (TCP/UDP port of the service) and optional fields `priority` (default = 0) and `weight` (default = 0).
 
 ### ACLs
 
@@ -329,5 +332,6 @@ Pull requests are also very welcome. Please create a topic branch for your propo
 - [Mario Ciccarelli](https://github.com/kartone)
 - [Peter Janes](https://github.com/peterjanes)
 - [Rafael Bodill](https://github.com/rafi)
+- [Romuald](https://github.com/rds13)
 - [Stuart Knight](https://github.com/blofeldthefish)
 - [Tom Meinlschmidt](https://github.com/tmeinlschmidt)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Variables are not required, unless specified.
 | `bind_acls`                  | `[]`                             | A list of ACL definitions, which are dicts with fields `name` and `match_list`. See below for an example.                   |
 | `bind_allow_query`           | `['localhost']`                  | A list of hosts that are allowed to query this DNS server. Set to ['any'] to allow all hosts                                |
 | `bind_allow_recursion`       | `['any']`                        | Similar to bind_allow_query, this option applies to recursive queries.                                                      |
-| `bind_check_names`           | `[]`                             | Check host names for compliance with RFC 952 and RFC 1123 and take the defined actioni (e.g. `warn`, `ignore`, `fail`). |
+| `bind_check_names`           | `[]`                             | Check host names for compliance with RFC 952 and RFC 1123 and take the defined actioni (e.g. `warn`, `ignore`, `fail`).     |
 | `bind_dnssec_enable`         | `true`                           | Is DNSSEC enabled                                                                                                           |
 | `bind_dnssec_validation`     | `true`                           | Is DNSSEC validation enabled                                                                                                |
 | `bind_extra_include_files`   | `[]`                             |                                                                                                                             |
@@ -58,6 +58,7 @@ Variables are not required, unless specified.
 | `- other_name_servers`       | `[]`                             | A list of the DNS servers outside of this domain.                                                                           |
 | `- services`                 | `[]`                             | A list of services to be advertized by SRV records                                                                          |
 | `- text`                     | `[]`                             | A list of dicts with fields `name` and `text`, specifying TXT records. `text` can be a list or string.                      |
+| `- naptr`                    | `[]`                             | A list of dicts with fields `name`, `order`, `pref`, `flags`, `service`, `regex` and `replacement` specifying NAPTR records.|
 | `bind_zone_file_mode`        | 0640                             | The file permissions for the main config file (named.conf)                                                                  |
 | `bind_zone_master_server_ip` | -                                | **(Required)** The IP address of the master DNS server.                                                                     |
 | `bind_zone_minimum_ttl`      | `1D`                             | Minimum TTL field in the SOA record.                                                                                        |
@@ -123,6 +124,14 @@ bind_zone_domains:
         weight: 100
         port: 88
         target: dc001
+    naptr:
+      - name: "sip"
+        order: 100
+        pref: 10
+        flags: "S"
+        service: "SIP+D2T"
+        regex: "!^.*$!sip:customer-service@example.com!"
+        replacement: "_sip._tcp.example.com."
 ```
 
 ### Minimal slave configuration

--- a/README.md
+++ b/README.md
@@ -26,50 +26,50 @@ See the [change log](CHANGELOG.md) for notable changes between versions.
 
 Variables are not required, unless specified.
 
-| Variable                     | Default                          | Comments (type)                                                                                                             |
-| :---                         | :---                             | :---                                                                                                                        |
-| `bind_acls`                  | `[]`                             | A list of ACL definitions, which are dicts with fields `name` and `match_list`. See below for an example.                   |
-| `bind_allow_query`           | `['localhost']`                  | A list of hosts that are allowed to query this DNS server. Set to ['any'] to allow all hosts                                |
-| `bind_allow_recursion`       | `['any']`                        | Similar to bind_allow_query, this option applies to recursive queries.                                                      |
-| `bind_check_names`           | `[]`                             | Check host names for compliance with RFC 952 and RFC 1123 and take the defined action (e.g. `warn`, `ignore`, `fail`).     |
-| `bind_dnssec_enable`         | `true`                           | Is DNSSEC enabled                                                                                                           |
-| `bind_dnssec_validation`     | `true`                           | Is DNSSEC validation enabled                                                                                                |
-| `bind_extra_include_files`   | `[]`                             |                                                                                                                             |
-| `bind_forward_only`          | `false`                          | If `true`, BIND is set up as a caching name server                                                                          |
-| `bind_forwarders`            | `[]`                             | A list of name servers to forward DNS requests to.                                                                          |
-| `bind_listen_ipv4`           | `['127.0.0.1']`                  | A list of the IPv4 address of the network interface(s) to listen on. Set to ['any'] to listen on all interfaces.            |
-| `bind_listen_ipv6`           | `['::1']`                        | A list of the IPv6 address of the network interface(s) to listen on                                                         |
-| `bind_log`                   | `data/named.run`                 | Path to the log file                                                                                                        |
-| `bind_other_logs`            | -                                | A list of logging channels to configure, with a separate dict for each domain, with relevant details                        |
-| `- allow_update`             | `['none']`                       | A list of hosts that are allowed to dynamically update this DNS zone.                                                       |
-| `- also_notify`              | -                                | A list of servers that will receive a notification when the master zone file is reloaded.                                   |
-| `- delegate`                 | `[]`                             | Zone delegation. See below this table for examples.                                                                         |
-| `bind_query_log`             | -                                | When defined (e.g. `data/query.log`), this will turn on the query log                                                       |
-| `bind_recursion`             | `false`                          | Determines whether requests for which the DNS server is not authoritative should be forwarded†.                             |
-| `bind_rrset_order`           | `random`                         | Defines order for DNS round robin (either `random` or `cyclic`)                                                             |
-| `bind_zone_dir`              | -                                | When defined, sets a custom absolute path to the server directory (for zone files, etc.) instead of the default.            |
-| `bind_zone_domains`          | n/a                              | A list of domains to configure, with a separate dict for each domain, with relevant details                                 |
-| `- allow_update`             | `['none']`                       | A list of hosts that are allowed to dynamically update this DNS zone.                                                       |
-| `- also_notify`              | -                                | A list of servers that will receive a notification when the master zone file is reloaded.                                   |
-| `- delegate`                 | `[]`                             | Zone delegation. See below this table for examples.                                                                         |
-| `- hostmaster_email`         | `hostmaster`                     | The e-mail address of the system administrator for the zone                                                                 |
-| `- hosts`                    | `[]`                             | Host definitions. See below this table for examples.                                                                        |
-| `- ipv6_networks`            | `[]`                             | A list of the IPv6 networks that are part of the domain, in CIDR notation (e.g. 2001:db8::/48)                              |
-| `- mail_servers`             | `[{name: mail, preference: 10}]` | A list of dicts (with fields `name` and `preference`) specifying the mail servers for this domain.                          |
-| `- name_servers`             | `[ansible_hostname]`             | A list of the DNS servers for this domain.                                                                                  |
-| `- name`                     | `example.com`                    | The domain name                                                                                                             |
-| `- networks`                 | `['10.0.2']`                     | A list of the networks that are part of the domain                                                                          |
-| `- other_name_servers`       | `[]`                             | A list of the DNS servers outside of this domain.                                                                           |
-| `- services`                 | `[]`                             | A list of services to be advertised by SRV records                                                                          |
-| `- text`                     | `[]`                             | A list of dicts with fields `name` and `text`, specifying TXT records. `text` can be a list or string.                      |
-| `- naptr`                    | `[]`                             | A list of dicts with fields `name`, `order`, `pref`, `flags`, `service`, `regex` and `replacement` specifying NAPTR records.|
-| `bind_zone_file_mode`        | 0640                             | The file permissions for the main config file (named.conf)                                                                  |
-| `bind_zone_master_server_ip` | -                                | **(Required)** The IP address of the master DNS server.                                                                     |
-| `bind_zone_minimum_ttl`      | `1D`                             | Minimum TTL field in the SOA record.                                                                                        |
-| `bind_zone_time_to_expire`   | `1W`                             | Time to expire field in the SOA record.                                                                                     |
-| `bind_zone_time_to_refresh`  | `1D`                             | Time to refresh field in the SOA record.                                                                                    |
-| `bind_zone_time_to_retry`    | `1H`                             | Time to retry field in the SOA record.                                                                                      |
-| `bind_zone_ttl`              | `1W`                             | Time to Live field in the SOA record.                                                                                       |
+| Variable                     | Default              | Comments (type)                                                                                                              |
+| :---                         | :---                 | :---                                                                                                                         |
+| `bind_acls`                  | `[]`                 | A list of ACL definitions, which are dicts with fields `name` and `match_list`. See below for an example.                    |
+| `bind_allow_query`           | `['localhost']`      | A list of hosts that are allowed to query this DNS server. Set to ['any'] to allow all hosts                                 |
+| `bind_allow_recursion`       | `['any']`            | Similar to bind_allow_query, this option applies to recursive queries.                                                       |
+| `bind_check_names`           | `[]`                 | Check host names for compliance with RFC 952 and RFC 1123 and take the defined action (e.g. `warn`, `ignore`, `fail`).       |
+| `bind_dnssec_enable`         | `true`               | Is DNSSEC enabled                                                                                                            |
+| `bind_dnssec_validation`     | `true`               | Is DNSSEC validation enabled                                                                                                 |
+| `bind_extra_include_files`   | `[]`                 |                                                                                                                              |
+| `bind_forward_only`          | `false`              | If `true`, BIND is set up as a caching name server                                                                           |
+| `bind_forwarders`            | `[]`                 | A list of name servers to forward DNS requests to.                                                                           |
+| `bind_listen_ipv4`           | `['127.0.0.1']`      | A list of the IPv4 address of the network interface(s) to listen on. Set to ['any'] to listen on all interfaces.             |
+| `bind_listen_ipv6`           | `['::1']`            | A list of the IPv6 address of the network interface(s) to listen on                                                          |
+| `bind_log`                   | `data/named.run`     | Path to the log file                                                                                                         |
+| `bind_other_logs`            | -                    | A list of logging channels to configure, with a separate dict for each domain, with relevant details                         |
+| `- allow_update`             | `['none']`           | A list of hosts that are allowed to dynamically update this DNS zone.                                                        |
+| `- also_notify`              | -                    | A list of servers that will receive a notification when the master zone file is reloaded.                                    |
+| `- delegate`                 | `[]`                 | Zone delegation. See below this table for examples.                                                                          |
+| `bind_query_log`             | -                    | When defined (e.g. `data/query.log`), this will turn on the query log                                                        |
+| `bind_recursion`             | `false`              | Determines whether requests for which the DNS server is not authoritative should be forwarded†.                              |
+| `bind_rrset_order`           | `random`             | Defines order for DNS round robin (either `random` or `cyclic`)                                                              |
+| `bind_zone_dir`              | -                    | When defined, sets a custom absolute path to the server directory (for zone files, etc.) instead of the default.             |
+| `bind_zone_domains`          | n/a                  | A list of domains to configure, with a separate dict for each domain, with relevant details                                  |
+| `- allow_update`             | `['none']`           | A list of hosts that are allowed to dynamically update this DNS zone.                                                        |
+| `- also_notify`              | -                    | A list of servers that will receive a notification when the master zone file is reloaded.                                    |
+| `- delegate`                 | `[]`                 | Zone delegation. See below this table for examples.                                                                          |
+| `- hostmaster_email`         | `hostmaster`         | The e-mail address of the system administrator for the zone                                                                  |
+| `- hosts`                    | `[]`                 | Host definitions. See below this table for examples.                                                                         |
+| `- ipv6_networks`            | `[]`                 | A list of the IPv6 networks that are part of the domain, in CIDR notation (e.g. 2001:db8::/48)                               |
+| `- mail_servers`             | `[]`                 | A list of dicts (with fields `name` and `preference`) specifying the mail servers for this domain.                           |
+| `- name_servers`             | `[ansible_hostname]` | A list of the DNS servers for this domain.                                                                                   |
+| `- name`                     | `example.com`        | The domain name                                                                                                              |
+| `- networks`                 | `['10.0.2']`         | A list of the networks that are part of the domain                                                                           |
+| `- other_name_servers`       | `[]`                 | A list of the DNS servers outside of this domain.                                                                            |
+| `- services`                 | `[]`                 | A list of services to be advertised by SRV records                                                                           |
+| `- text`                     | `[]`                 | A list of dicts with fields `name` and `text`, specifying TXT records. `text` can be a list or string.                       |
+| `- naptr`                    | `[]`                 | A list of dicts with fields `name`, `order`, `pref`, `flags`, `service`, `regex` and `replacement` specifying NAPTR records. |
+| `bind_zone_file_mode`        | 0640                 | The file permissions for the main config file (named.conf)                                                                   |
+| `bind_zone_master_server_ip` | -                    | **(Required)** The IP address of the master DNS server.                                                                      |
+| `bind_zone_minimum_ttl`      | `1D`                 | Minimum TTL field in the SOA record.                                                                                         |
+| `bind_zone_time_to_expire`   | `1W`                 | Time to expire field in the SOA record.                                                                                      |
+| `bind_zone_time_to_refresh`  | `1D`                 | Time to refresh field in the SOA record.                                                                                     |
+| `bind_zone_time_to_retry`    | `1H`                 | Time to retry field in the SOA record.                                                                                       |
+| `bind_zone_ttl`              | `1W`                 | Time to Live field in the SOA record.                                                                                        |
 
 † Best practice for an authoritative name server is to leave recursion turned off. However, [for some cases](http://www.zytrax.com/books/dns/ch7/queries.html#allow-query-cache) it may be necessary to have recursion turned on.
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,57 +42,6 @@
   check_mode: false
   tags: bind
 
-- name: Read forward zone hashes
-  shell: 'grep -s "^; Hash:" {{ bind_zone_dir }}/{{ item.name }} || true'
-  changed_when: false
-  check_mode: false
-  register: forward_hashes_temp
-  with_items:
-    - "{{ bind_zone_domains }}"
-
-- name: create dict of forward hashes
-  set_fact:
-    forward_hashes: "{{ forward_hashes|default([]) + [ {'hash': item.stdout|default(), 'name': item.item.name} ] }}"
-  with_items:
-    - "{{ forward_hashes_temp.results }}"
-
-
-- name: Read reverse ipv4 zone hashes
-  shell: "grep -s \"^; Hash:\" {{ bind_zone_dir }}/{{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr.arpa || true"
-  changed_when: false
-  check_mode: false
-  register: reverse_hashes_temp
-  with_subelements:
-    - "{{ bind_zone_domains }}"
-    - networks
-    - flags:
-      skip_missing: true
-
-- name: create dict of reverse hashes
-  set_fact:
-    reverse_hashes: "{{ reverse_hashes|default([]) + [ {'hash': item.0.stdout|default(), 'network': item.1} ] }}"
-  with_subelements:
-    - "{{ reverse_hashes_temp.results }}"
-    - item
-
-- name: Read reverse ipv6 zone hashes
-  shell: "grep -s \"^; Hash:\" {{ bind_zone_dir }}/{{ (item.1 | ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):-1] }} || true"
-  changed_when: false
-  check_mode: false
-  register: reverse_hashes_ipv6_temp
-  with_subelements:
-    - "{{ bind_zone_domains }}"
-    - ipv6_networks
-    - flags:
-      skip_missing: true
-
-- name: create dict of reverse ipv6 hashes
-  set_fact:
-    reverse_hashes_ipv6: "{{ reverse_hashes_ipv6|default([]) + [ {'hash': item.0.stdout|default(), 'network': item.1} ] }}"
-  with_subelements:
-    - "{{ reverse_hashes_ipv6_temp.results }}"
-    - item
-
 - name: Set up the machine as a master DNS server
   include_tasks: master.yml
   when: bind_zone_master_server_ip in ansible_all_ipv4_addresses

--- a/tasks/master.yml
+++ b/tasks/master.yml
@@ -2,6 +2,74 @@
 # Set up a BIND master server
 ---
 
+- name: Read forward zone hashes
+  shell: 'grep -s "^; Hash:" {{ bind_zone_dir }}/{{ item.name }} || true'
+  changed_when: false
+  check_mode: false
+  register: forward_hashes_temp
+  with_items:
+    - "{{ bind_zone_domains }}"
+  run_once: true
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: create dict of forward hashes
+  set_fact:
+    forward_hashes: "{{ forward_hashes|default([]) + [ {'hash': item.stdout|default(), 'name': item.item.name} ] }}"
+  with_items:
+    - "{{ forward_hashes_temp.results }}"
+  run_once: true
+  loop_control:
+    label: "{{ item.item.name }}"
+
+- name: Read reverse ipv4 zone hashes
+  shell: "grep -s \"^; Hash:\" {{ bind_zone_dir }}/{{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr.arpa || true"
+  changed_when: false
+  check_mode: false
+  register: reverse_hashes_temp
+  with_subelements:
+    - "{{ bind_zone_domains }}"
+    - networks
+    - flags:
+      skip_missing: true
+  run_once: true
+  loop_control:
+    label: "{{ item.1 }}"
+
+- name: create dict of reverse hashes
+  set_fact:
+    reverse_hashes: "{{ reverse_hashes|default([]) + [ {'hash': item.0.stdout|default(), 'network': item.1} ] }}"
+  with_subelements:
+    - "{{ reverse_hashes_temp.results }}"
+    - item
+  run_once: true
+  loop_control:
+    label: "{{ item.1.name |default(item.0.cmd.split(' ')[4]) }}"
+
+- name: Read reverse ipv6 zone hashes
+  shell: "grep -s \"^; Hash:\" {{ bind_zone_dir }}/{{ (item.1 | ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):-1] }} || true"
+  changed_when: false
+  check_mode: false
+  register: reverse_hashes_ipv6_temp
+  with_subelements:
+    - "{{ bind_zone_domains }}"
+    - ipv6_networks
+    - flags:
+      skip_missing: true
+  run_once: true
+  loop_control:
+    label: "{{ item.1 }}"
+
+- name: create dict of reverse ipv6 hashes
+  set_fact:
+    reverse_hashes_ipv6: "{{ reverse_hashes_ipv6|default([]) + [ {'hash': item.0.stdout|default(), 'network': item.1} ] }}"
+  with_subelements:
+    - "{{ reverse_hashes_ipv6_temp.results }}"
+    - item
+  run_once: true
+  loop_control:
+    label: "{{ item.1.name |default(item.0.cmd.split(' ')[4]) }}"
+
 - name: Master | Main BIND config file (master)
   template:
     src: master_etc_named.conf.j2
@@ -25,6 +93,8 @@
     validate: 'named-checkzone -d {{ item.name }} %s'
   with_items:
     - "{{ bind_zone_domains }}"
+  loop_control:
+    label: "{{ item.name }}"
   notify: reload bind
   tags: bind
 
@@ -42,6 +112,8 @@
     - networks
     - flags:
       skip_missing: true
+  loop_control:
+    label: "{{ item.1 }}"
   notify: reload bind
   tags: bind
 
@@ -59,5 +131,7 @@
     - ipv6_networks
     - flags:
       skip_missing: true
+  loop_control:
+    label: "{{ item.1 }}"
   notify: reload bind
   tags: bind

--- a/tasks/master.yml
+++ b/tasks/master.yml
@@ -48,7 +48,7 @@
 - name: Master | Create reverse IPv6 lookup zone file
   template:
     src: reverse_zone_ipv6.j2
-    dest: "{{bind_zone_dir}}/{{ (item.1 | ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):-1] }}"
+    dest: "{{ bind_zone_dir }}/{{ (item.1 | ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):-1] }}"
     owner: "{{ bind_owner }}"
     group: "{{ bind_group }}"
     mode: "{{ bind_zone_file_mode }}"

--- a/templates/bind_zone.j2
+++ b/templates/bind_zone.j2
@@ -58,23 +58,23 @@ $TTL {{ _zone_data['ttl'] }}
 
 {% if _zone_data['mname']|length > 0 %}
 {% for ns in _zone_data['mname'] %}
-                     IN  NS     {{ ns }}{% if not ns|regex_search('\.$') %}.{{ _zone_data['domain'] }}.{% endif %}
+                           IN  NS     {{ ns }}{% if not ns|regex_search('\.$') %}.{{ _zone_data['domain'] }}.{% endif %}
 
 {% endfor %}
 {% else %}
-                     IN  NS     {{ ansible_hostname }}.{{ _zone_data['domain'] }}.
+                           IN  NS     {{ ansible_hostname }}.{{ _zone_data['domain'] }}.
 {% endif %}
 {% for ns in _zone_data['aname'] %}
-                     IN  NS     {{ ns }}.
+                           IN  NS     {{ ns }}.
 {% endfor %}
 
 {% for mail in _zone_data['mail'] %}
-{% if loop.first %}@{% else %} {% endif %}                    IN  MX     {{ mail.preference}}  {{ mail.name }}{% if not mail.name.endswith('.') %}.{{ _zone_data['domain'] }}.{% endif %} 
+{% if loop.first %}@{% else %} {% endif %}                          IN  MX     {{ mail.preference}}  {{ mail.name }}{% if not mail.name.endswith('.') %}.{{ _zone_data['domain'] }}.{% endif %} 
 {% endfor %}
 
 {% if _zone_data['delegate']|length > 0 %}
 {% for host in _zone_data['delegate'] %}
-{{ host.zone.ljust(20) }} IN  NS     {{ host.dns }}
+{{ host.zone.ljust(20) }}       IN  NS     {{ host.dns }}
 {% endfor %}
 {% endif %}
 
@@ -82,33 +82,33 @@ $TTL {{ _zone_data['ttl'] }}
 {% for host in _zone_data['hosts'] %}
 {% if host.ip is defined %}
 {% if host.ip is string %}
-{{ host.name.ljust(20) }} IN  A      {{ host.ip }}
+{{ host.name.ljust(20) }}{{ (host.ttl|string).rjust(6) if host.ttl is defined else ''.ljust(6) }} IN  A      {{ host.ip }}
 {% else %}
 {% for ip in host.ip %}
-{{ host.name.ljust(20) }} IN  A      {{ ip }}
+{{ host.name.ljust(20) }}{{ (host.ttl|string).rjust(6) if host.ttl is defined else ''.ljust(6) }} IN  A      {{ ip }}
 {% endfor %}
 {% endif %}
 {% endif %}
 {% if host.ipv6 is defined %}
 {% if host.ipv6 is string %}
-{{ host.name.ljust(20) }} IN  AAAA   {{ host.ipv6 }}
+{{ host.name.ljust(20) }}{{ (host.ttl|string).rjust(6) if host.ttl is defined else ''.ljust(6) }} IN  AAAA   {{ host.ipv6 }}
 {% else %}
 {% for ip6 in host.ipv6 %}
-{{ host.name.ljust(20) }} IN  AAAA   {{ ip6 }}
+{{ host.name.ljust(20) }}{{ (host.ttl|string).rjust(6) if host.ttl is defined else ''.ljust(6) }} IN  AAAA   {{ ip6 }}
 {% endfor %}
 {% endif %}
 {% endif %}
 {% if host.aliases is defined %}
 {% for alias in host.aliases %}
-{{ alias.ljust(20) }} IN  CNAME  {{ host.name }}
+{{ alias.ljust(20) }}{{ (host.ttl|string).rjust(6) if host.ttl is defined else ''.ljust(6) }} IN  CNAME  {{ host.name }}
 {% endfor %}
 {% endif %}
 {% endfor %}
 {% else %}
-{{ ansible_hostname.ljust(20) }} IN A     {{ ansible_default_ipv4.address }}
+{{ ansible_hostname.ljust(26) }} IN A     {{ ansible_default_ipv4.address }}
 {% endif %}
 {% for service in _zone_data['services'] %}
-{{ service.name.ljust(20) }} IN  SRV    {{ service.priority|default('0') }} {{ service.weight|default('0') }} {{ service.port }} {{ service.target }}
+{{ service.name.ljust(20) }}{{ (service.ttl|string).rjust(6) if service.ttl is defined else ''.ljust(6) }} IN  SRV    {{ service.priority|default('0') }} {{ service.weight|default('0') }} {{ service.port }} {{ service.target }}
 {% endfor %}
 {% for text in _zone_data['text'] %}
 {% if text.text is string %}

--- a/templates/bind_zone.j2
+++ b/templates/bind_zone.j2
@@ -83,10 +83,10 @@ $TTL {{ _zone_data['ttl'] }}
 {% for host in _zone_data['hosts'] %}
 {% if host.ip is defined %}
 {% if host.ip is string %}
-{% if "GENERATE" not in host.name.upper() %}
+{% if "$GENERATE" not in host.name.upper() %}
 {{ host.name.ljust(20) }}{{ (host.ttl|string).rjust(6) if host.ttl is defined else ''.ljust(6) }} IN  A      {{ host.ip }}
 {% endif %}
-{% if "GENERATE" in host.name.upper() %}
+{% if "$GENERATE" in host.name.upper() %}
 {{ host.name.ljust(20) }}{{ (host.ttl|string).rjust(6) if host.ttl is defined else ''.ljust(6) }} IN  A      {{ host.ip }}
 {% endif %}
 {% else %}
@@ -106,10 +106,10 @@ $TTL {{ _zone_data['ttl'] }}
 {% endif %}
 {% if host.aliases is defined %}
 {% for alias in host.aliases %}
-{% if "GENERATE" not in host.name.upper() %}
+{% if "$GENERATE" not in host.name.upper() %}
 {{ (alias.name|default(alias)).ljust(20) }}{{ (host.ttl|string).rjust(6) if host.ttl is defined else ''.ljust(6) }} IN  {{ alias.type|default('cname')|upper}}  {{ host.name }}
 {% endif %}
-{% if "GENERATE" in host.name.upper() %}
+{% if "$GENERATE" in host.name.upper() %}
 {{ alias.ljust(20) }} IN  CNAME  {{ host.name.rsplit(None, 1)[1] }}
 {% endif %}
 {% endfor %}

--- a/templates/bind_zone.j2
+++ b/templates/bind_zone.j2
@@ -83,7 +83,12 @@ $TTL {{ _zone_data['ttl'] }}
 {% for host in _zone_data['hosts'] %}
 {% if host.ip is defined %}
 {% if host.ip is string %}
+{% if "GENERATE" not in host.name.upper() %}
 {{ host.name.ljust(20) }}{{ (host.ttl|string).rjust(6) if host.ttl is defined else ''.ljust(6) }} IN  A      {{ host.ip }}
+{% endif %}
+{% if "GENERATE" in host.name.upper() %}
+{{ host.name.ljust(20) }}{{ (host.ttl|string).rjust(6) if host.ttl is defined else ''.ljust(6) }} IN  A      {{ host.ip }}
+{% endif %}
 {% else %}
 {% for ip in host.ip %}
 {{ host.name.ljust(20) }}{{ (host.ttl|string).rjust(6) if host.ttl is defined else ''.ljust(6) }} IN  A      {{ ip }}
@@ -101,7 +106,12 @@ $TTL {{ _zone_data['ttl'] }}
 {% endif %}
 {% if host.aliases is defined %}
 {% for alias in host.aliases %}
+{% if "GENERATE" not in host.name.upper() %}
 {{ (alias.name|default(alias)).ljust(20) }}{{ (host.ttl|string).rjust(6) if host.ttl is defined else ''.ljust(6) }} IN  {{ alias.type|default('cname')|upper}}  {{ host.name }}
+{% endif %}
+{% if "GENERATE" in host.name.upper() %}
+{{ alias.ljust(20) }} IN  CNAME  {{ host.name.rsplit(None, 1)[1] }}
+{% endif %}
 {% endfor %}
 {% endif %}
 {% if host.sshfp is defined %}

--- a/templates/bind_zone.j2
+++ b/templates/bind_zone.j2
@@ -100,7 +100,7 @@ $TTL {{ _zone_data['ttl'] }}
 {% endif %}
 {% if host.aliases is defined %}
 {% for alias in host.aliases %}
-{{ alias.ljust(20) }}{{ (host.ttl|string).rjust(6) if host.ttl is defined else ''.ljust(6) }} IN  CNAME  {{ host.name }}
+{{ (alias.name|default(alias)).ljust(20) }}{{ (host.ttl|string).rjust(6) if host.ttl is defined else ''.ljust(6) }} IN  {{ alias.type|default('cname')|upper}}  {{ host.name }}
 {% endfor %}
 {% endif %}
 {% if host.sshfp is defined %}

--- a/templates/bind_zone.j2
+++ b/templates/bind_zone.j2
@@ -22,6 +22,7 @@
 {% set _ = _zone_data.update({'delegate': item.delegate|default([])}) %}
 {% set _ = _zone_data.update({'services': item.services|default([])}) %}
 {% set _ = _zone_data.update({'text': item.text|default([])}) %}
+{% set _ = _zone_data.update({'naptr': item.naptr|default([])}) %}
 {#
  #  Compare the zone file hash with the current zone data hash and set serial
  #  accordingly
@@ -123,4 +124,7 @@ $TTL {{ _zone_data['ttl'] }}
 {{ text.name.ljust(20) }} IN  TXT    "{{ entry }}"
 {%   endfor %}
 {% endif %}
+{% endfor %}
+{% for naptr in _zone_data['naptr'] %}
+{{ naptr.name.ljust(20) }} IN  NAPTR  {{ naptr.order|default('100') }} {{ naptr.pref|default('10') }} "{{ naptr.flags }}" "{{ naptr.service }}" "{{ naptr.regex }}" {{ naptr.replacement }}
 {% endfor %}

--- a/templates/bind_zone.j2
+++ b/templates/bind_zone.j2
@@ -103,6 +103,11 @@ $TTL {{ _zone_data['ttl'] }}
 {{ alias.ljust(20) }}{{ (host.ttl|string).rjust(6) if host.ttl is defined else ''.ljust(6) }} IN  CNAME  {{ host.name }}
 {% endfor %}
 {% endif %}
+{% if host.sshfp is defined %}
+{% for sshfp in host.sshfp %}
+{{ host.name.ljust(20) }} IN SSHFP {{ sshfp}}
+{% endfor %}
+{% endif %}
 {% endfor %}
 {% else %}
 {{ ansible_hostname.ljust(26) }} IN A     {{ ansible_default_ipv4.address }}

--- a/templates/master_etc_named.conf.j2
+++ b/templates/master_etc_named.conf.j2
@@ -2,6 +2,7 @@
 // named.conf
 //
 {{ ansible_managed | comment('c') }}
+//
 {% for acl in bind_acls %}
 acl "{{ acl.name }}" {
 {% for match in acl.match_list %}
@@ -11,13 +12,13 @@ acl "{{ acl.name }}" {
 
 {% endfor %}
 options {
-  listen-on port 53 { {{ bind_listen_ipv4|join(';') }}; };
-  listen-on-v6 port 53 { {{ bind_listen_ipv6|join(';') }}; };
+  listen-on port 53 { {{ bind_listen_ipv4|join('; ') }}; };
+  listen-on-v6 port 53 { {{ bind_listen_ipv6|join('; ') }}; };
   directory   "{{ bind_dir }}";
   dump-file   "{{ bind_dir }}/data/cache_dump.db";
   statistics-file "{{ bind_dir }}/data/named_stats.txt";
   memstatistics-file "{{ bind_dir }}/data/named_mem_stats.txt";
-  allow-query     { {{ bind_allow_query|join(';') }}; };
+  allow-query     { {{ bind_allow_query|join('; ') }}; };
 {% if bind_acls|length != 0 %}
   allow-transfer  { {% for acl in bind_acls %}"{{ acl.name }}"; {% endfor %}};
 {% endif %}
@@ -80,10 +81,10 @@ zone "{{ bind_zone.name }}" IN {
   file "{{ bind_zone_dir }}/{{ bind_zone.name }}";
   notify yes;
 {% if bind_zone.also_notify is defined %}
-  also-notify  { {{ bind_zone.also_notify|join(';') }}; };
+  also-notify  { {{ bind_zone.also_notify|join('; ') }}; };
 {% endif %}
 {% if bind_zone.allow_update is defined %}
-  allow-update { {{ bind_zone.allow_update|join(';') }}; };
+  allow-update { {{ bind_zone.allow_update|join('; ') }}; };
 {% else %}
   allow-update { none; };
 {% endif %}
@@ -99,10 +100,10 @@ zone "{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr
   file "{{ bind_zone_dir }}/{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr.arpa";
   notify yes;
 {% if bind_zone.also_notify is defined %}
-  also-notify  { {{ bind_zone.also_notify|join(';') }}; };
+  also-notify  { {{ bind_zone.also_notify|join('; ') }}; };
 {% endif %}
 {% if bind_zone.allow_update is defined %}
-  allow-update { {{ bind_zone.allow_update|join(';') }}; };
+  allow-update { {{ bind_zone.allow_update|join('; ') }}; };
 {% else %}
   allow-update { none; };
 {% endif %}
@@ -117,10 +118,10 @@ zone "{{ (network | ipaddr('revdns'))[-(9+(network|regex_replace('^.*/','')|int)
   file "{{ bind_zone_dir }}/{{ (network | ipaddr('revdns'))[-(9+(network|regex_replace('^.*/','')|int)//2):-1] }}";
   notify yes;
 {% if bind_zone.also_notify is defined %}
-  also-notify  { {{ bind_zone.also_notify|join(';') }}; };
+  also-notify  { {{ bind_zone.also_notify|join('; ') }}; };
 {% endif %}
 {% if bind_zone.allow_update is defined %}
-  allow-update { {{ bind_zone.allow_update|join(';') }}; };
+  allow-update { {{ bind_zone.allow_update|join('; ') }}; };
 {% else %}
   allow-update { none; };
 {% endif %}

--- a/templates/master_etc_named.conf.j2
+++ b/templates/master_etc_named.conf.j2
@@ -65,6 +65,18 @@ logging {
   };
   category queries { querylog; };
 {% endif %}
+
+{% if bind_other_logs is defined %}
+{% for log in bind_other_logs %}
+  channel {{ log.name }} {
+    file "{{ log.file }}" versions {{ log.versions }} size {{ log.size }};
+    severity dynamic;
+    print-time yes;
+  };
+  category "{{ log.name }}" { "{{ log.name }}"; };
+{% endfor %}
+{% endif %}
+
 };
 
 {% for file in bind_default_zone_files %}

--- a/templates/reverse_zone.j2
+++ b/templates/reverse_zone.j2
@@ -55,35 +55,35 @@ $ORIGIN {{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr
 
 {% if _zone_data['mname']|length > 0 %}
 {% for ns in _zone_data['mname'] %}
-                 IN  NS   {{ ns }}{% if not ns|regex_search('\.$') %}.{{ _zone_data['domain'] }}.{% endif %}
+                       IN  NS   {{ ns }}{% if not ns|regex_search('\.$') %}.{{ _zone_data['domain'] }}.{% endif %}
 
 {% endfor %}
 {% else %}
-                 IN  NS   {{ ansible_hostname }}.{{ _zone_data['domain'] }}.
+                       IN  NS   {{ ansible_hostname }}.{{ _zone_data['domain'] }}.
 {% endif %}
 {% for ns in _zone_data['aname'] %}
-                 IN  NS   {{ ns }}.
+                       IN  NS   {{ ns }}.
 {% endfor %}
 
 {% if _zone_data['hosts']|length > 0 %}
 {% for host in _zone_data['hosts'] %}
 {% if host.ip is defined %}
 {% if host.ip == item.1 %}
-@                IN  PTR  {{ host.name }}.{{ _zone_data['domain'] }}.
+@                      IN  PTR  {{ host.name }}.{{ _zone_data['domain'] }}.
 {% else %}
 {% if host.ip is string and host.ip.startswith(item.1) %}
 {% if host.name == '@' %}
-{{ ('.'.join(host.ip.replace(item.1+'.','').split('.')[::-1])).ljust(16) }} IN  PTR  {{ _zone_data['domain'] }}.
+{{ ('.'.join(host.ip.replace(item.1+'.','').split('.')[::-1])).ljust(16) }}{{ (host.ttl|string).rjust(6) if host.ttl is defined else ''.ljust(6) }} IN  PTR  {{ _zone_data['domain'] }}.
 {% else %}
-{{ ('.'.join(host.ip.replace(item.1+'.','').split('.')[::-1])).ljust(16) }} IN  PTR  {{ host.name }}.{{ _zone_data['domain'] }}.
+{{ ('.'.join(host.ip.replace(item.1+'.','').split('.')[::-1])).ljust(16) }}{{ (host.ttl|string).rjust(6) if host.ttl is defined else ''.ljust(6) }} IN  PTR  {{ host.name }}.{{ _zone_data['domain'] }}.
 {% endif %}
 {% else %}
 {% for ip in host.ip %}
 {% if ip.startswith(item.1) %}
-{{ ('.'.join(ip.replace(item.1+'.','').split('.')[::-1])).ljust(16) }} IN  PTR  {{ _zone_data['domain'] }}.
+{{ ('.'.join(ip.replace(item.1+'.','').split('.')[::-1])).ljust(16) }}{{ (host.ttl|string).rjust(6) if host.ttl is defined else ''.ljust(6) }} IN  PTR  {{ _zone_data['domain'] }}.
 {% if host.name == '@' %}
 {% else %}
-{{ ('.'.join(ip.replace(item.1+'.','').split('.')[::-1])).ljust(16) }} IN  PTR  {{ host.name }}.{{ _zone_data['domain'] }}.
+{{ ('.'.join(ip.replace(item.1+'.','').split('.')[::-1])).ljust(16) }}{{ (host.ttl|string).rjust(6) if host.ttl is defined else ''.ljust(6) }} IN  PTR  {{ host.name }}.{{ _zone_data['domain'] }}.
 {% endif %}
 {% endif %}
 {% endfor %}
@@ -92,5 +92,5 @@ $ORIGIN {{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr
 {% endif %}
 {% endfor %}
 {% else %}
-{{ ('.'.join(ansible_default_ipv4.address.replace(item.1+'.','').split('.')[::-1])).ljust(16) }} IN  PTR  {{ ansible_hostname }}.{{ _zone_data['domain'] }}.
+{{ ('.'.join(ansible_default_ipv4.address.replace(item.1+'.','').split('.')[::-1])).ljust(16) }}{{ (host.ttl|string).rjust(6) if host.ttl is defined else ''.ljust(6) }} IN  PTR  {{ ansible_hostname }}.{{ _zone_data['domain'] }}.
 {% endif %}

--- a/templates/reverse_zone.j2
+++ b/templates/reverse_zone.j2
@@ -75,10 +75,10 @@ $ORIGIN {{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr
 {% if host.name == '@' %}
 {{ ('.'.join(host.ip.replace(item.1+'.','').split('.')[::-1])).ljust(16) }}{{ (host.ttl|string).rjust(6) if host.ttl is defined else ''.ljust(6) }} IN  PTR  {{ _zone_data['domain'] }}.
 {% else %}
-{% if "GENERATE" not in host.name.upper() %}
+{% if "$GENERATE" not in host.name.upper() %}
 {{ ('.'.join(host.ip.replace(item.1+'.','').split('.')[::-1])).ljust(16) }}{{ (host.ttl|string).rjust(6) if host.ttl is defined else ''.ljust(6) }} IN  PTR  {{ host.name }}.{{ _zone_data['domain'] }}.
 {% endif %}
-{% if "GENERATE" in host.name.upper() %}
+{% if "$GENERATE" in host.name.upper() %}
 {{ host.name.rsplit(None, 1)[0] }} {{ ('.'.join(host.ip.replace(item.1+'.','').split('.')[::-1])).ljust(16) }} IN  PTR  {{ host.name.rsplit(None, 1)[1] }}.{{ _zone_data['domain'] }}.
 {% endif %}
 {% endif %}

--- a/templates/reverse_zone.j2
+++ b/templates/reverse_zone.j2
@@ -75,7 +75,12 @@ $ORIGIN {{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr
 {% if host.name == '@' %}
 {{ ('.'.join(host.ip.replace(item.1+'.','').split('.')[::-1])).ljust(16) }}{{ (host.ttl|string).rjust(6) if host.ttl is defined else ''.ljust(6) }} IN  PTR  {{ _zone_data['domain'] }}.
 {% else %}
+{% if "GENERATE" not in host.name.upper() %}
 {{ ('.'.join(host.ip.replace(item.1+'.','').split('.')[::-1])).ljust(16) }}{{ (host.ttl|string).rjust(6) if host.ttl is defined else ''.ljust(6) }} IN  PTR  {{ host.name }}.{{ _zone_data['domain'] }}.
+{% endif %}
+{% if "GENERATE" in host.name.upper() %}
+{{ host.name.rsplit(None, 1)[0] }} {{ ('.'.join(host.ip.replace(item.1+'.','').split('.')[::-1])).ljust(16) }} IN  PTR  {{ host.name.rsplit(None, 1)[1] }}.{{ _zone_data['domain'] }}.
+{% endif %}
 {% endif %}
 {% else %}
 {% for ip in host.ip %}

--- a/templates/reverse_zone_ipv6.j2
+++ b/templates/reverse_zone_ipv6.j2
@@ -55,35 +55,35 @@ $ORIGIN {{ (item.1 | ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)
 
 {% if _zone_data['mname']|length > 0 %}
 {% for ns in _zone_data['mname'] %}
-                 IN  NS   {{ ns }}{% if not ns|regex_search('\.$') %}.{{ _zone_data['domain'] }}.{% endif %}
+                       IN  NS   {{ ns }}{% if not ns|regex_search('\.$') %}.{{ _zone_data['domain'] }}.{% endif %}
 
 {% endfor %}
 {% else %}
-                 IN  NS   {{ ansible_hostname }}.{{ _zone_data['domain'] }}.
+                       IN  NS   {{ ansible_hostname }}.{{ _zone_data['domain'] }}.
 {% endif %}
 {% for ns in _zone_data['aname'] %}
-                 IN  NS   {{ ns }}.
+                       IN  NS   {{ ns }}.
 {% endfor %}
 
 {% if _zone_data['hosts']|length > 0 %}
 {% for host in _zone_data['hosts'] %}
 {% if host.ipv6 is defined %}
 {% if host.ipv6 == item.1 %}
-@                IN  PTR  {{ host.name }}.{{ _zone_data['domain'] }}.
+@                      IN  PTR  {{ host.name }}.{{ _zone_data['domain'] }}.
 {% else %}
 {% if host.ipv6 is string and host.ipv6.startswith(item.1|regex_replace('/.*$','')) %}
 {% if host.name == '@' %}
-{{ host.ipv6 | ipaddr('revdns') }} IN  PTR  {{ _zone_data['domain'] }}.
+{{ host.ipv6 | ipaddr('revdns') }}{{ (host.ttl|string).rjust(6) if host.ttl is defined else ''.ljust(6) }} IN  PTR  {{ _zone_data['domain'] }}.
 {% else %}
-{{ host.ipv6 | ipaddr('revdns') }} IN  PTR  {{ host.name }}.{{ _zone_data['domain'] }}.
+{{ host.ipv6 | ipaddr('revdns') }}{{ (host.ttl|string).rjust(6) if host.ttl is defined else ''.ljust(6) }} IN  PTR  {{ host.name }}.{{ _zone_data['domain'] }}.
 {% endif %}
 {% else %}
 {% for ip in host.ipv6 %}
 {% if ip.startswith(item.1|regex_replace('/.*$','')) %}
-{{ ip | ipaddr('revdns') }} IN  PTR  {{ _zone_data['domain'] }}.
+{{ ip | ipaddr('revdns') }}{{ (host.ttl|string).rjust(6) if host.ttl is defined else ''.ljust(6) }} IN  PTR  {{ _zone_data['domain'] }}.
 {% if host.name == '@' %}
 {% else %}
-{{ ip | ipaddr('revdns') }} IN  PTR  {{ host.name }}.{{ _zone_data['domain'] }}.
+{{ ip | ipaddr('revdns') }}{{ (host.ttl|string).rjust(6) if host.ttl is defined else ''.ljust(6) }} IN  PTR  {{ host.name }}.{{ _zone_data['domain'] }}.
 {% endif %}
 {% endif %}
 {% endfor %}
@@ -92,5 +92,5 @@ $ORIGIN {{ (item.1 | ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)
 {% endif %}
 {% endfor %}
 {% else %}
-{{ ansible_default_ipv6.address | ipaddr('revdns') }} IN  PTR  {{ ansible_hostname }}.{{ _zone_data['domain'] }}.
+{{ ansible_default_ipv6.address | ipaddr('revdns') }}{{ (host.ttl|string).rjust(6) if host.ttl is defined else ''.ljust(6) }} IN  PTR  {{ ansible_hostname }}.{{ _zone_data['domain'] }}.
 {% endif %}

--- a/templates/slave_etc_named.conf.j2
+++ b/templates/slave_etc_named.conf.j2
@@ -40,6 +40,7 @@ options {
 
   pid-file "/run/named/named.pid";
   session-keyfile "/run/named/session.key";
+
 {% if bind_query_log is defined %}
   querylog yes;
 {% endif %}
@@ -100,4 +101,3 @@ zone "{{ (network | ipaddr('revdns'))[-(9+(network|regex_replace('^.*/','')|int)
 {% endif %}
 {% endfor %}
 {% endif %}
-


### PR DESCRIPTION
ISC bind9 ARM [the $GENERATE Directive](https://ftp.isc.org/isc/bind9/cur/9.12/doc/arm/Bv9ARM.ch05.html#generate_directive) and http://www.zytrax.com/books/dns/ch8/generate.html

Add support for using `$GENERATE` to facilitate iterative records creation.

Examples:
```
          - name: '$GENERATE 1-5 ww$'
            ip: 172.21.12.$
```

```
          - name: 'dev-srv001'
            ip: 172.21.12.9
            aliases:
              - '$GENERATE 3-9  wwwdev$'
              - '$GENERATE 3-9  ftp$'
```

```
          - name: '$GENERATE 32-96 g$'
            ip: 172.21.99.$
            aliases:
              - '$GENERATE 32-96  guest-dhcp-$'
```