### PR TITLE
Ensure directory for cached slaves zones

### DIFF
--- a/tasks/slave.yml
+++ b/tasks/slave.yml
@@ -13,3 +13,12 @@
     validate: 'named-checkconf %s'
   notify: reload bind
   tags: bind
+
+- name: Slave | ensure directory for cached slaves zones
+  file:
+    path: "{{ bind_dir }}/slaves"
+    state: directory
+    owner: "{{ bind_owner }}"
+    group: "{{ bind_group }}"
+    mode: '0770'
+    setype: named_cache_t


### PR DESCRIPTION
This is necessary because this directory is hard-coded in the slave_etc_named.conf.j2 template.

For Red Hat based distros this directory is created by default with bind package installation:
$ ls -alhdZ /var/named/slaves/
drwxrwx---. named named system_u:object_r:named_cache_t:s0 /var/named/slaves/

But for Debian based distributions the directory is not created at all.