### PR TITLE
Add FreeBSD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/bertvv/ansible-role-bind.svg?branch=master)](https://travis-ci.org/bertvv/ansible-role-bind)
 
-An Ansible role for setting up BIND ISC as an **authoritative-only** DNS server for multiple domains on EL7 or Ubuntu Server. Specifically, the responsibilities of this role are to:
+An Ansible role for setting up BIND ISC as an **authoritative-only** DNS server for multiple domains. Specifically, the responsibilities of this role are to:
 
 - install BIND
 - set up the main configuration file

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -66,7 +66,5 @@ bind_zone_time_to_retry: "1H"
 bind_zone_time_to_expire: "1W"
 bind_zone_minimum_ttl: "1D"
 
-# Custom location for master zone files
-bind_zone_dir: "{{ bind_dir }}"
 # File mode for master zone files (needs to be something like 0660 for dynamic updates)
 bind_zone_file_mode: "0640"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,10 +1,20 @@
 ---
 galaxy_info:
   author: Bert Van Vreckem
-  description: Sets up ISC BIND on RHEL/CentOS 6/7, Ubuntu 16.04/18.04 LTS (Xenial/Bionic), or Arch Linux as an authoritative DNS server for one or more domains (master and/or slave).
+  description: Sets up ISC BIND as an authoritative DNS server for one or more domains (master and/or slave).
   license: BSD
   min_ansible_version: 2.7
   platforms:
+    - name: ArchLinux
+      versions:
+        - any
+    - name: Debian
+      versions:
+        - jessie
+        - stretch
+    - name: FreeBSD
+      versions:
+        - any
     - name: EL
       versions:
         - 6
@@ -13,13 +23,6 @@ galaxy_info:
       versions:
         - xenial
         - bionic
-    - name: Debian
-      versions:
-        - jessie
-        - stretch
-    - name: ArchLinux
-      versions:
-        - any
   galaxy_tags:
     - networking
     - system

--- a/templates/master_etc_named.conf.j2
+++ b/templates/master_etc_named.conf.j2
@@ -39,12 +39,12 @@ options {
   dnssec-lookaside auto;
 
   /* Path to ISC DLV key */
-  bindkeys-file "/etc/named.iscdlv.key";
+  bindkeys-file "{{ bind_bindkeys_file }}";
 
   managed-keys-directory "{{ bind_dir }}/dynamic";
 
-  pid-file "/run/named/named.pid";
-  session-keyfile "/run/named/session.key";
+  pid-file "{{ bind_pid_file }}";
+  session-keyfile "{{ bind_session_keyfile }}";
 {% if bind_query_log is defined %}
 
   querylog yes;

--- a/templates/slave_etc_named.conf.j2
+++ b/templates/slave_etc_named.conf.j2
@@ -36,12 +36,12 @@ options {
   dnssec-lookaside auto;
 
   /* Path to ISC DLV key */
-  bindkeys-file "/etc/named.iscdlv.key";
+  bindkeys-file "{{ bind_bindkeys_file }}";
 
   managed-keys-directory "{{ bind_dir }}/dynamic";
 
-  pid-file "/run/named/named.pid";
-  session-keyfile "/run/named/session.key";
+  pid-file "{{ bind_pid_file }}";
+  session-keyfile "{{ bind_session_keyfile }}";
 
 {% if bind_query_log is defined %}
   querylog yes;
@@ -82,7 +82,7 @@ include "{{ file }}";
 zone "{{ bind_zone.name }}" IN {
   type slave;
   masters { {{ bind_zone_master_server_ip }}; };
-  file "slaves/{{ bind_zone.name }}";
+  file "{{ bind_slave_dir }}/{{ bind_zone.name }}";
 {% if bind_zone.delegate is defined %}
   forwarders {};
 {% endif %}
@@ -93,7 +93,7 @@ zone "{{ bind_zone.name }}" IN {
 zone "{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr.arpa" IN {
   type slave;
   masters { {{ bind_zone_master_server_ip }}; };
-  file "slaves/{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr.arpa";
+  file "{{ bind_slave_dir }}/{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr.arpa";
 };
 {% endfor %}
 {% endif %}
@@ -103,7 +103,7 @@ zone "{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr
 zone "{{ (network | ipaddr('revdns'))[-(9+(network|regex_replace('^.*/','')|int)//2):] }}" IN {
   type slave;
   masters { {{ bind_zone_master_server_ip }}; };
-  file "slaves/{{ (network | ipaddr('revdns'))[-(9+(network|regex_replace('^.*/','')|int)//2):-1] }}";
+  file "{{ bind_slave_dir }}/{{ (network | ipaddr('revdns'))[-(9+(network|regex_replace('^.*/','')|int)//2):-1] }}";
 };
 {% endfor %}
 {% endif %}

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -22,3 +22,11 @@ bind_auth_file: "{{ bind_conf_dir }}/{{ auth_file }}"
 
 bind_owner: root
 bind_group: named
+
+bind_bindkeys_file: "/etc/named.iscdlv.key"
+bind_pid_file: "/run/named/pid"
+bind_session_keyfile: "/run/named/session.key"
+
+# Custom location for zone files
+bind_zone_dir: "{{ bind_dir }}"
+bind_slave_dir: "{{ bind_dir }}/slaves"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -23,3 +23,11 @@ bind_auth_file: "{{ bind_conf_dir }}/{{ auth_file }}"
 
 bind_owner: root
 bind_group: bind
+
+bind_bindkeys_file: "/etc/named.iscdlv.key"
+bind_pid_file: "/run/named/pid"
+bind_session_keyfile: "/run/named/session.key"
+
+# Custom location for master zone files
+bind_zone_dir: "{{ bind_dir }}"
+bind_slave_dir: "{{ bind_dir }}/slaves"

--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -1,0 +1,32 @@
+# roles/bind/vars/Debian.yml
+---
+
+bind_packages:
+  - py36-netaddr
+  - bind911
+
+bind_service: named
+
+# Main config file
+bind_config: /usr/local/etc/namedb/named.conf
+
+# Localhost zone
+bind_default_zone_files:
+  - /usr/local/etc/namedb/named.conf.default-zones
+
+# Directory with run-time stuff
+bind_dir: /var/cache/named
+bind_conf_dir: "/usr/local/etc/namedb/"
+auth_file: "auth_transfer.conf"
+bind_auth_file: "{{ bind_conf_dir }}/{{ auth_file }}"
+
+bind_owner: bind
+bind_group: bind
+
+bind_bindkeys_file: "/usr/local/etc/namedb/bind.keys"
+bind_pid_file: "/var/run/named/pid"
+bind_session_keyfile: "/var/run/named/session.key"
+
+# Custom location for master zone files
+bind_zone_dir: "{{ bind_dir }}/master"
+bind_slave_dir: "{{ bind_dir }}/slave"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -24,3 +24,11 @@ bind_auth_file: "{{ bind_conf_dir }}/{{ auth_file }}"
 
 bind_owner: root
 bind_group: named
+
+bind_bindkeys_file: "/etc/named.iscdlv.key"
+bind_pid_file: "/run/named/pid"
+bind_session_keyfile: "/run/named/session.key"
+
+# Custom location for master zone files
+bind_zone_dir: "{{ bind_dir }}"
+bind_slave_dir: "{{ bind_dir }}/slaves"


### PR DESCRIPTION
Adds support for FreeBSD to the BIND role:
* Removed the long list of supported operating systems as it's getting
  unmanagable.
* Alphabetically sorted platforms in meta to make it easier as more platforms
  are added.
* Turned the slave directory, bindkeys-file, pid-file and session-keyfile into
  variables.