### PR TITLE
allow specify versions and size for query log files

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Variables are not required, unless specified.
 | `- allow_update`             | `['none']`           | A list of hosts that are allowed to dynamically update this DNS zone.                                                        |
 | `- also_notify`              | -                    | A list of servers that will receive a notification when the master zone file is reloaded.                                    |
 | `- delegate`                 | `[]`                 | Zone delegation. See below this table for examples.                                                                          |
-| `bind_query_log`             | -                    | When defined (e.g. `data/query.log`), this will turn on the query log                                                        |
+| `bind_query_log`             | -                    | A dict with fields `file` (e.g. `data/query.log`), `versions`, `size`, when defined this will turn on the query log                                                        |
 | `bind_recursion`             | `false`              | Determines whether requests for which the DNS server is not authoritative should be forwarded†.                              |
 | `bind_rrset_order`           | `random`             | Defines order for DNS round robin (either `random` or `cyclic`)                                                              |
 | `bind_statistcs_channels`    | `false`              | if `true`, BIND is configured with a statistics_channels clause (currently only supports a single inet)                      |

--- a/templates/master_etc_named.conf.j2
+++ b/templates/master_etc_named.conf.j2
@@ -65,7 +65,11 @@ logging {
   };
 {% if bind_query_log is defined %}
   channel querylog {
-    file "{{ bind_query_log }}" versions 600 size 20m;
+    {% if bind_query_log.file is defined %}
+      file "{{ bind_query_log.file }}" versions {{ bind_query_log.versions }} size {{ bind_query_log.size }};
+    {% else %}
+      file "{{ bind_query_log }}" versions 600 size 20m;
+    {% endif %}
     severity dynamic;
     print-time yes;
   };


### PR DESCRIPTION
Use a dict to specify filename, number for versions to keep and file size.
This is compatible with old behaviour where only filename was defined.