### PR TITLE
Removes dnssec-lookaside from master/slave configurations

### DIFF
--- a/templates/master_etc_named.conf.j2
+++ b/templates/master_etc_named.conf.j2
@@ -36,7 +36,6 @@ options {
 
   dnssec-enable {{ bind_dnssec_enable }};
   dnssec-validation {{ bind_dnssec_validation }};
-  dnssec-lookaside auto;
 
   /* Path to ISC DLV key */
   bindkeys-file "/etc/named.iscdlv.key";

--- a/templates/slave_etc_named.conf.j2
+++ b/templates/slave_etc_named.conf.j2
@@ -33,7 +33,6 @@ options {
 
   dnssec-enable {{ bind_dnssec_enable }};
   dnssec-validation {{ bind_dnssec_validation }};
-  dnssec-lookaside auto;
 
   /* Path to ISC DLV key */
   bindkeys-file "/etc/named.iscdlv.key";


### PR DESCRIPTION
dnssec-lookaside: 'auto' is removed now from bind.
It is a quick fix to make it working again.

"The ISC DNSSEC Lookaside Validation (DLV) service has been shut down; all DLV records in the dlv.isc.org zone have been removed. References to the service have been removed from BIND documentation. Lookaside validation is no longer used by default by delv. The DLV key has been removed from bind.keys. Setting dnssec-lookaside to auto or to use dlv.isc.org as a trust anchor results in a warning being issued."

https://ftp.isc.org/isc/bind9/9.9.12/RELEASE-NOTES-bind-9.9.12.html

Should we make it configurable?