### PR TITLE
Rename word 'hosts' since its reserved

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Variables are not required, unless specified.
 | `- also_notify`              | -                    | A list of servers that will receive a notification when the master zone file is reloaded.                                    |
 | `- delegate`                 | `[]`                 | Zone delegation. See below this table for examples.                                                                          |
 | `- hostmaster_email`         | `hostmaster`         | The e-mail address of the system administrator for the zone                                                                  |
-| `- hosts`                    | `[]`                 | Host definitions. See below this table for examples.                                                                         |
+| `- bind_hosts`                    | `[]`                 | Host definitions. See below this table for examples.                                                                         |
 | `- ipv6_networks`            | `[]`                 | A list of the IPv6 networks that are part of the domain, in CIDR notation (e.g. 2001:db8::/48)                               |
 | `- mail_servers`             | `[]`                 | A list of dicts (with fields `name` and `preference`) specifying the mail servers for this domain.                           |
 | `- name_servers`             | `[ansible_hostname]` | A list of the DNS servers for this domain.                                                                                   |
@@ -85,7 +85,7 @@ Even though only variable `bind_zone_master_server_ip` is required for the role 
 | `  - name`                   | V      | V     |
 | `  - networks`               | V      | V     |
 | `  - name_servers`           | V      | --    |
-| `  - hosts`                  | V      | --    |
+| `  - bind_hosts`                  | V      | --    |
 | `bind_listen_ipv4`           | V      | V     |
 | `bind_allow_query`           | V      | V     |
 
@@ -94,7 +94,7 @@ Even though only variable `bind_zone_master_server_ip` is required for the role 
 ```Yaml
 bind_zone_domains:
   - name: mydomain.com
-    hosts:
+    bind_hosts:
       - name: pub01
         ip: 192.0.2.1
         ipv6: 2001:db8::1
@@ -152,7 +152,7 @@ bind_zone_domains:
 
 ### Hosts
 
-Host names that this DNS server should resolve can be specified in `hosts` as a list of dicts with fields `name`, `ip`,  `aliases` and `sshfp`. Aliases can be CNAME (default) or DNAME records.
+Host names that this DNS server should resolve can be specified in `bind_hosts` as a list of dicts with fields `name`, `ip`,  `aliases` and `sshfp`. Aliases can be CNAME (default) or DNAME records.
 
 To allow to surf to http://example.com/, set the host name of your web server to `'@'` (must be quoted!). In BIND syntax, `@` indicates the domain name itself.
 

--- a/templates/bind_zone.j2
+++ b/templates/bind_zone.j2
@@ -18,7 +18,7 @@
 {% set _ = _zone_data.update({'retry': bind_zone_time_to_retry}) %}
 {% set _ = _zone_data.update({'expire': bind_zone_time_to_expire}) %}
 {% set _ = _zone_data.update({'minimum': bind_zone_minimum_ttl}) %}
-{% set _ = _zone_data.update({'hosts': item.hosts|default([])}) %}
+{% set _ = _zone_data.update({'hosts': item.bind_hosts|default([])}) %}
 {% set _ = _zone_data.update({'delegate': item.delegate|default([])}) %}
 {% set _ = _zone_data.update({'services': item.services|default([])}) %}
 {% set _ = _zone_data.update({'text': item.text|default([])}) %}

--- a/templates/reverse_zone.j2
+++ b/templates/reverse_zone.j2
@@ -17,7 +17,7 @@
 {% set _ = _zone_data.update({'retry': bind_zone_time_to_retry}) %}
 {% set _ = _zone_data.update({'expire': bind_zone_time_to_expire}) %}
 {% set _ = _zone_data.update({'minimum': bind_zone_minimum_ttl}) %}
-{% set _ = _zone_data.update({'hosts': item.0.hosts|default([]) | selectattr('ip', 'defined') | selectattr('ip', 'string') | selectattr('ip', 'search', '^'+item.1) | list}) %}
+{% set _ = _zone_data.update({'hosts': item.0.bind_hosts|default([]) | selectattr('ip', 'defined') | selectattr('ip', 'string') | selectattr('ip', 'search', '^'+item.1) | list}) %}
 {% set _ = _zone_data.update({'revip': ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1]))}) %}
 {#
  #  Compare the zone file hash with the current zone data hash and set serial

--- a/templates/reverse_zone_ipv6.j2
+++ b/templates/reverse_zone_ipv6.j2
@@ -17,7 +17,7 @@
 {% set _ = _zone_data.update({'retry': bind_zone_time_to_retry}) %}
 {% set _ = _zone_data.update({'expire': bind_zone_time_to_expire}) %}
 {% set _ = _zone_data.update({'minimum': bind_zone_minimum_ttl}) %}
-{% set _ = _zone_data.update({'hosts': item.0.hosts|default([]) | selectattr('ipv6','defined') | selectattr('ipv6','string') | selectattr('ipv6', 'search', '^'+item.1|regex_replace('/.*$','')) | list }) %}
+{% set _ = _zone_data.update({'hosts': item.0.bind_hosts|default([]) | selectattr('ipv6','defined') | selectattr('ipv6','string') | selectattr('ipv6', 'search', '^'+item.1|regex_replace('/.*$','')) | list }) %}
 {% set _ = _zone_data.update({'revip': (item.1 | ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):] }) %}
 {#
  #  Compare the zone file hash with the current zone data hash and set serial


### PR DESCRIPTION
Hi Bert

Whilst working with your role, I noted that hosts was being flagged as a warning in plays since its a reserved variable.

This might well be the way I was executing the play but the pull requests trivial changes remove this warning.

Hope its helpful to you.
