### PR TITLE
Fix querylog version & size setting for slave

### DIFF
--- a/templates/slave_etc_named.conf.j2
+++ b/templates/slave_etc_named.conf.j2
@@ -61,7 +61,11 @@ logging {
   };
 {% if bind_query_log is defined %}
   channel querylog {
-    file "{{ bind_query_log }}" versions 600 size 20m;
+    {% if bind_query_log.file is defined %}
+      file "{{ bind_query_log.file }}" versions {{ bind_query_log.versions }} size {{ bind_query_log.size }};
+    {% else %}
+      file "{{ bind_query_log }}" versions 600 size 20m;
+    {% endif %}
     severity dynamic;
     print-time yes;
   };


### PR DESCRIPTION
In #105 the bind_query_log option was enhanced to make version and size configurable. This feature was missing for slave instances.

This patch to the template for slave servers fixes it.