### PR TITLE
Fix master/slave with key error

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,14 +42,6 @@
   check_mode: false
   tags: bind
 
-- name: Set up the machine as a master DNS server
-  include_tasks: master.yml
-  when: bind_zone_master_server_ip in ansible_all_ipv4_addresses
-
-- name: Set up the machine as a slave DNS server
-  include_tasks: slave.yml
-  when: bind_zone_master_server_ip not in ansible_all_ipv4_addresses
-
 # file to set keys for XFR authentication
 - name: create extra config file for authenticated XFR request
   tags: pretask
@@ -60,6 +52,14 @@
     owner: root
     group: "{{ bind_group }}"
   when: bind_dns_keys is defined and bind_dns_keys|length > 0
+
+- name: Set up the machine as a master DNS server
+  include_tasks: master.yml
+  when: bind_zone_master_server_ip in ansible_all_ipv4_addresses
+
+- name: Set up the machine as a slave DNS server
+  include_tasks: slave.yml
+  when: bind_zone_master_server_ip not in ansible_all_ipv4_addresses
 
 - name: Start BIND service
   service:


### PR DESCRIPTION
As proposed in https://github.com/bertvv/ansible-role-bind/issues/114,
this moves the auth transfer template task to be executed
before the master slave setup tasks.