### PR TITLE
Replace manual Docker tests with Molecule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,42 +1,28 @@
 ---
+language: python
+
+# Use the new container infrastructure
 sudo: required
 
-env:
-  matrix:
-    - DISTRIBUTION: centos
-      VERSION: 7
-    - DISTRIBUTION: ubuntu
-      VERSION: 16.04
-    - DISTRIBUTION: ubuntu
-      VERSION: 18.04
-    - DISTRIBUTION: debian
-      VERSION: 9
-
+#Enable docker support
 services:
   - docker
 
-before_install:
-  # Install latest Git
-  - sudo apt-get update
-  - sudo apt-get install --only-upgrade git
-  # Allow fetching other branches than master
-  - git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
-  # Fetch the branch with test code
-  - git fetch origin docker-tests
-  - git worktree add docker-tests origin/docker-tests
+install:
+  # Install dependencies for Molecule test
+  - python3 -m pip install ansible
+  - python3 -m pip install pytest
+  - python3 -m pip install testinfra
+  - python3 -m pip install molecule
+  - python3 -m pip install docker
+
+  # Check ansible and molecule version
+  - ansible --version
+  - molecule --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
 
 script:
-  # Running the test script the first time will set up the master DNS server
-  # with IP 172.17.0.2. Running it the second time sets up the slave DNS
-  # server with IP 172.17.0.3.
-  - ./docker-tests/docker-tests.sh
-  - ./docker-tests/docker-tests.sh
+  - molecule test 
 
-  # Run functional tests on both master and slave server
-  - SUT_IP=172.17.0.2 ./docker-tests/functional-tests.sh
-  # Ensure the slave gets the chance to receive zone updates from the master
-  - sleep 6s
-  - SUT_IP=172.17.0.3 ./docker-tests/functional-tests.sh
-
-notifications:
-  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
   # Install dependencies for Molecule test
   - python3 -m pip install ansible
   - python3 -m pip install pytest
-  - python3 -m pip install testinfra
+  - python3 -m pip install netaddr
   - python3 -m pip install molecule
   - python3 -m pip install docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,13 @@ language: python
 sudo: required
 
 env:
+  global:
+    - ROLE_NAME: bind
   matrix:
-    - DISTRIBUTION: centos
-      VERSION: 7
-    - DISTRIBUTION: ubuntu
-      VERSION: 1604
-    - DISTRIBUTION: ubuntu
-      VERSION: 1804
-    - DISTRIBUTION: debian
-      VERSION: 9
+    - MOLECULE_DISTRO: centos7
+    - MOLECULE_DISTRO: debian9
+    - MOLECULE_DISTRO: ubuntu1604
+    - MOLECULE_DISTRO: ubuntu1804
 
 #Enable docker support
 services:
@@ -21,11 +19,7 @@ services:
 
 install:
   # Install dependencies for Molecule test
-  - python3 -m pip install ansible
-  - python3 -m pip install pytest
-  - python3 -m pip install netaddr
-  - python3 -m pip install molecule
-  - python3 -m pip install docker
+  - python3 -m pip install molecule yamllint ansible-lint docker
 
   # Check ansible and molecule version
   - ansible --version
@@ -34,6 +28,15 @@ install:
   # Create ansible.cfg with correct roles_path
   - printf '[defaults]\nroles_path=../' >ansible.cfg
 
-script:
-  - DISTRIBUTION=$DISTRIBUTION VERSION=$VERSION molecule test 
+before_script:
+  #Renames ansible-role-bind to bertvv.bind to make it match with Ansible Galaxy
+  - cd ../
+  - mv ansible-role-$ROLE_NAME bertvv.$ROLE_NAME
+  - cd bertvv.$ROLE_NAME
 
+script:
+  #Run molecule test
+  - molecule test 
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,17 @@ language: python
 # Use the new container infrastructure
 sudo: required
 
+env:
+  matrix:
+    - DISTRIBUTION: centos
+      VERSION: 7
+    - DISTRIBUTION: ubuntu
+      VERSION: 16.04
+    - DISTRIBUTION: ubuntu
+      VERSION: 18.04
+    - DISTRIBUTION: debian
+      VERSION: 9
+
 #Enable docker support
 services:
   - docker
@@ -24,5 +35,5 @@ install:
   - printf '[defaults]\nroles_path=../' >ansible.cfg
 
 script:
-  - molecule test 
+  - DISTRIBUTION=$DISTRIBUTION VERSION=$VERSION molecule test 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ env:
     - DISTRIBUTION: centos
       VERSION: 7
     - DISTRIBUTION: ubuntu
-      VERSION: 16.04
+      VERSION: 1604
     - DISTRIBUTION: ubuntu
-      VERSION: 18.04
+      VERSION: 1804
     - DISTRIBUTION: debian
       VERSION: 9
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ services:
 
 install:
   # Install dependencies for Molecule test
-  - python3 -m pip install molecule yamllint ansible-lint docker
+  - python3 -m pip install molecule yamllint ansible-lint docker netaddr
 
   # Check ansible and molecule version
   - ansible --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ services:
 
 install:
   # Install dependencies for Molecule test
-  - python3 -m pip install molecule yamllint ansible-lint docker netaddr
-
+  - python3 -m pip install molecule yamllint ansible-lint docker
+  - python3 -m pip install netaddr
   # Check ansible and molecule version
   - ansible --version
   - molecule --version

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Ansible role `bind`
 
 [![Build Status](https://travis-ci.org/bertvv/ansible-role-bind.svg?branch=master)](https://travis-ci.org/bertvv/ansible-role-bind)
-[![Build Status](https://travis-ci.org/RobinOphalvens/ansible-role-bind.svg?branch=master)](https://travis-ci.org/RobinOphalvens/ansible-role-bind)
 
 An Ansible role for setting up BIND ISC as an **authoritative-only** DNS server for multiple domains on EL7 or Ubuntu Server. Specifically, the responsibilities of this role are to:
 
@@ -342,13 +341,13 @@ Testing 192.168.56.53
 ```
 ### Running Molecule tests
 
-Molecule handles the complexity and lifecyle of Docker containers, for testing purposes,by allowing developers to specify which containers should be created in .yaml files. This Molecule configuration will create two Centos 7 containers, one master and one slave, and then runs the role on top of them. To test the containers, a verify playbook runs the same automated acceptance BATS as specified above. 
+Molecule handles the complexity and lifecyle of Docker containers, for testing purposes,by allowing developers to specify which containers should be created in .yaml files. This Molecule configuration will create two Centos 7 containers, one master and one slave, and then runs the role on top of them. To test the containers, a verify playbook runs the same automated acceptance BATS as specified above. This whole process is automated with a single command. 
 
 #### Requirements and installation
 
 1. Docker should be installed on the system
 2. As recommended by Molecule, create a python virtual environment
-3. Install Molecule and the Docker driver with `python3 -m pip install molecule docker netaddr`
+3. Install Molecule, the Docker driver and python-netaddr with `python3 -m pip install molecule docker netaddr`
 4. Navigate to the root of the role directory and run `molecule test`
 
 Molecule automatically deletes the containers after a test. If you would like to check out the containers yourself, run `molecule converge` followed by `molecule login --host {HOSTNAME}`. 

--- a/README.md
+++ b/README.md
@@ -385,3 +385,4 @@ Pull requests are also very welcome. Please create a topic branch for your propo
 - [Stuart Knight](https://github.com/blofeldthefish)
 - [Tom Meinlschmidt](https://github.com/tmeinlschmidt)
 - [jadjay](https://github.com/jadjay)
+- [Robin Ophalvens](https://github.com/RobinOphalvens)

--- a/README.md
+++ b/README.md
@@ -339,6 +339,18 @@ Testing 192.168.56.53
  ✓ The `dig` command should be installed
 [...]
 ```
+### Running Molecule tests
+
+Molecule handles the complexity and lifecyle of Docker containers, for testing purposes,by allowing developers to specify which containers should be created in .yaml files. This Molecule configuration will create two Centos 7 containers, one master and one slave, and then runs the role on top of them. To test the containers, a verify playbook runs the same automated acceptance BATS as specified above. 
+
+#### Requirements and installation
+
+1. Docker should be installed on the system
+2. As recommended by Molecule, create a python virtual environment
+3. Install Molecule and the Docker driver with `python3 -m pip install molecule docker netaddr`
+4. Navigate to the root of the role directory and run `molecule test`
+
+Molecule automatically deletes the containers after a test. If you would like to check out the containers yourself, run `molecule converge` followed by `molecule login --host {HOSTNAME}`. 
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -347,11 +347,18 @@ Molecule handles the complexity and lifecyle of Docker containers, for testing p
 
 1. Docker should be installed on the system
 2. As recommended by Molecule, create a python virtual environment
-3. Install Molecule, the Docker driver and python-netaddr with `python3 -m pip install molecule docker netaddr`
+3. Install the software tools `python3 -m pip install molecule docker netaddr yamllint ansible-lint`
 4. Navigate to the root of the role directory and run `molecule test`
 
 Molecule automatically deletes the containers after a test. If you would like to check out the containers yourself, run `molecule converge` followed by `molecule login --host {HOSTNAME}`. 
 
+The default config will run Molecule with 2 Centos 7 containers. This can be modified by setting the `MOLECULE_DISTRO` varible with the command. 
+
+The supported distros are centos7, ubuntu1604, ubuntu1804 and debian9
+
+``` bash
+MOLECULE_DISTRO=debian9 molecule test
+```
 ## License
 
 BSD

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Ansible role `bind`
 
 [![Build Status](https://travis-ci.org/bertvv/ansible-role-bind.svg?branch=master)](https://travis-ci.org/bertvv/ansible-role-bind)
+[![Build Status](https://travis-ci.org/RobinOphalvens/ansible-role-bind.svg?branch=master)](https://travis-ci.org/RobinOphalvens/ansible-role-bind)
 
 An Ansible role for setting up BIND ISC as an **authoritative-only** DNS server for multiple domains on EL7 or Ubuntu Server. Specifically, the responsibilities of this role are to:
 

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,137 @@
+---
+- name: Converge
+  hosts: all
+  vars:
+    bind_zone_dir: /var/local/named-zones
+    bind_zone_file_mode: '0660'
+    bind_allow_query:
+      - any
+    bind_listen_ipv4:
+      - any
+    bind_listen_ipv6:
+      - any
+    bind_acls:
+      - name: acl1
+        match_list:
+          - 172.17.0.0/16
+    bind_forwarders:
+      - '8.8.8.8'
+      - '8.8.4.4'
+    bind_recursion: true
+    bind_query_log: 'data/query.log'
+    bind_check_names: 'master ignore'
+    bind_zone_master_server_ip: 172.17.0.2
+    bind_zone_minimum_ttl: "2D"
+    bind_zone_ttl: "2W"
+    bind_zone_time_to_refresh: "2D"
+    bind_zone_time_to_retry: "2H"
+    bind_zone_time_to_expire: "2W"
+    bind_zone_domains:
+      - name: 'example.com'
+        networks:
+          - '192.0.2'
+        ipv6_networks:
+          - '2001:db9::/48'
+        name_servers:
+          - ns1.acme-inc.com.
+          - ns2.acme-inc.com.
+        hostmaster_email: admin
+        hosts:
+          - name: srv001
+            ip: 192.0.2.1
+            ipv6: '2001:db9::1'
+            aliases:
+              - www
+          - name: srv002
+            ip: 192.0.2.2
+            ipv6: '2001:db9::2'
+          - name: mail001
+            ip: 192.0.2.10
+            ipv6: '2001:db9::3'
+        mail_servers:
+          - name: mail001
+            preference: 10
+      - name: 'acme-inc.com'
+        networks:
+          - '172.17'
+          - '10'
+        ipv6_networks:
+          - '2001:db8::/48'
+        name_servers:
+          - ns1
+          - ns2
+        hosts:
+          - name: ns1
+            ip: 172.17.0.2
+          - name: ns2
+            ip: 172.17.0.3
+          - name: srv001
+            ip: 172.17.1.1
+            ipv6: 2001:db8::1
+            aliases:
+              - www
+          - name: srv002
+            ip: 172.17.1.2
+            ipv6: 2001:db8::2
+            aliases:
+              - mysql
+          - name: mail001
+            ip: 172.17.2.1
+            ipv6: 2001:db8::d:1
+            aliases:
+              - smtp
+              - mail-in
+          - name: mail002
+            ip: 172.17.2.2
+            ipv6: 2001:db8::d:2
+          - name: mail003
+            ip: 172.17.2.3
+            ipv6: 2001:db8::d:3
+            aliases:
+              - imap
+              - mail-out
+          - name: srv010
+            ip: 10.0.0.10
+          - name: srv011
+            ip: 10.0.0.11
+          - name: srv012
+            ip: 10.0.0.12
+        mail_servers:
+          - name: mail001
+            preference: 10
+          - name: mail002
+            preference: 20
+        services:
+          - name: _ldap._tcp
+            weight: 100
+            port: 88
+            target: srv010
+        text:
+          - name: _kerberos
+            text: KERBEROS.ACME-INC.COM
+          - name: '@'
+            text:
+              - 'some text'
+              - 'more text'
+  tasks:
+    - name: "Include ansible-role-bind"
+      include_role:
+        name: "ansible-role-bind"
+  post_tasks:
+    - name: "Transfer bats to container"
+      copy:
+              #src: /home/robin/Projects/ansible-role-bind/files/dns.bats
+        src: dns.bats
+        dest: /dns.bats
+        owner: root
+        group: root
+        mode: 773
+    - name: "Transfer script to container"
+      copy:
+              #src: /home/robin/Projects/ansible-role-bind/files/functional-tests.sh
+        src: functional-tests.sh
+        dest: /functional-tests.sh
+        owner: root
+        group: root
+        mode: 773
+

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -113,10 +113,8 @@
             text:
               - 'some text'
               - 'more text'
-  tasks:
-    - name: "Include ansible-role-bind"
-      include_role:
-        name: "ansible-role-bind"
+  roles:
+    - role: bertvv.bind
   post_tasks:
     - name: "Transfer bats to container"
       copy:

--- a/molecule/default/files/dns.bats
+++ b/molecule/default/files/dns.bats
@@ -1,0 +1,263 @@
+#! /usr/bin/env bats
+#
+# Functional tests for a DNS server set up as a test case for Ansible role
+# bertvv.bind
+#
+# The variable SUT_IP, the IP address of the System Under Test must be set
+# outside of the script.
+
+#{{{ Helper functions
+
+# Usage: assert_forward_lookup NAME DOMAIN IP
+# Exits with status 0 if NAME.DOMAIN resolves to IP, a nonzero
+# status otherwise
+assert_forward_lookup() {
+  local name="$1"
+  local domain="$2"
+  local ip="$3"
+
+  local result
+  result=$(dig @"${SUT_IP}" "${name}.${domain}" +short)
+
+  echo "Expected: ${ip}"
+  echo "Actual  : ${result}"
+  [ "${ip}" = "${result}" ]
+}
+
+# Usage: assert_forward_ipv6_lookup NAME DOMAIN IP
+assert_forward_ipv6_lookup() {
+  local name="${1}"
+  local domain="${2}"
+  local ip="${3}"
+
+  local result
+  result=$(dig @"${SUT_IP}" AAAA "${name}.${domain}" +short)
+
+  echo "Expected: ${ip}"
+  echo "Actual  : ${result}"
+  [ "${ip}" = "${result}" ]
+}
+
+# Usage: assert_reverse_lookup NAME DOMAIN IP
+# Exits with status 0 if a reverse lookup on IP resolves to NAME,
+# a nonzero status otherwise
+assert_reverse_lookup() {
+  local name="$1"
+  local domain="$2"
+  local ip="$3"
+
+  local expected="${name}.${domain}."
+  local result
+  result=$(dig @"${SUT_IP}" -x "${ip}" +short)
+
+  echo "Expected: ${expected}"
+  echo "Actual  : ${result}"
+  [ "${expected}" = "${result}" ]
+}
+
+# Usage: assert_alias_lookup ALIAS NAME DOMAIN IP
+# Exits with status 0 if a forward lookup on NAME resolves to the
+# host name NAME.DOMAIN and to IP, a nonzero status otherwise
+assert_alias_lookup() {
+  local alias="$1"
+  local name="$2"
+  local domain="$3"
+  local ip="$4"
+  local result
+  result=$(dig @"${SUT_IP}" "${alias}.${domain}" +short)
+
+  grep "${name}\\.${domain}\\." <<<  "${result}"
+  grep "${ip}" <<< "${result}"
+}
+
+# Usage: assert_ns_lookup DOMAIN NS_NAME...
+# Exits with status 0 if all specified host names occur in the list of
+# name servers for the domain.
+assert_ns_lookup() {
+  local domain="${1}"
+  shift
+  local result
+  result=$(dig @"${SUT_IP}" "${domain}" NS +short)
+
+  [ -n "${result}" ] # the list of name servers should not be empty
+  while (( "$#" )); do
+    grep "$1\\." <<< "${result}"
+    shift
+  done
+}
+
+# Usage: assert_mx_lookup DOMAIN PREF1 NAME1 PREF2 NAME2...
+#   e.g. assert_mx_lookup example.com 10 mailsrv1 20 mailsrv2
+# Exits with status 0 if all specified host names occur in the list of
+# mail servers for the domain.
+assert_mx_lookup() {
+  local domain="${1}"
+  shift
+  local result
+  result=$(dig @"${SUT_IP}" "${domain}" MX +short)
+
+  [ -n "${result}" ] # the list of name servers should not be empty
+  while (( "$#" )); do
+    grep "$1 $2\\.${domain}\\." <<< "${result}"
+    shift
+    shift
+  done
+}
+
+# Usage: assert_srv_lookup DOMAIN SERVICE WEIGHT PORT TARGET
+#  e.g.  assert_srv_lookup example.com _ldap._tcp 0 100 88 ldapsrv
+assert_srv_lookup() {
+  local domain="${1}"
+  shift
+  local service="${1}"
+  shift
+  local expected="${*}.${domain}."
+  local result
+  result=$(dig @"${SUT_IP}" SRV "${service}.${domain}" +short)
+
+  echo "expected: ${expected}"
+  echo "actual  : ${result}"
+  [ "${result}" = "${expected}" ]
+}
+
+# Perform a TXT record lookup
+# Usage: assert_txt_lookup NAME TEXT...
+# e.g. assert_txt_lookup _kerberos.example.com KERBEROS.EXAMPLE.COM
+assert_txt_lookup() {
+  local name="$1"
+  shift
+  local result
+  result=$(dig @"${SUT_IP}" TXT "${name}" +short)
+
+  echo "expected: ${*}"
+  echo "actual  : ${result}"
+  while [ "$#" -ne "0" ]; do
+    grep "${1}" <<< "${result}"
+    shift
+  done
+}
+
+
+#}}}
+
+@test "Forward lookups acme-inc.com" {
+  #                     host name  domain       IP
+  assert_forward_lookup ns1        acme-inc.com 172.17.0.2
+  assert_forward_lookup ns2        acme-inc.com 172.17.0.3
+  assert_forward_lookup srv001     acme-inc.com 172.17.1.1
+  assert_forward_lookup srv002     acme-inc.com 172.17.1.2
+  assert_forward_lookup mail001    acme-inc.com 172.17.2.1
+  assert_forward_lookup mail002    acme-inc.com 172.17.2.2
+  assert_forward_lookup mail003    acme-inc.com 172.17.2.3
+  assert_forward_lookup srv010     acme-inc.com 10.0.0.10
+  assert_forward_lookup srv011     acme-inc.com 10.0.0.11
+  assert_forward_lookup srv012     acme-inc.com 10.0.0.12
+}
+
+@test "Reverse lookups acme-inc.com" {
+  #                     host name  domain       IP
+  assert_reverse_lookup ns1        acme-inc.com 172.17.0.2
+  assert_reverse_lookup ns2        acme-inc.com 172.17.0.3
+  assert_reverse_lookup srv001     acme-inc.com 172.17.1.1
+  assert_reverse_lookup srv002     acme-inc.com 172.17.1.2
+  assert_reverse_lookup mail001    acme-inc.com 172.17.2.1
+  assert_reverse_lookup mail002    acme-inc.com 172.17.2.2
+  assert_reverse_lookup mail003    acme-inc.com 172.17.2.3
+  assert_reverse_lookup srv010     acme-inc.com 10.0.0.10
+  assert_reverse_lookup srv011     acme-inc.com 10.0.0.11
+  assert_reverse_lookup srv012     acme-inc.com 10.0.0.12
+}
+
+@test "Alias lookups acme-inc.com" {
+  #                   alias      hostname  domain       IP
+  assert_alias_lookup www        srv001    acme-inc.com 172.17.1.1
+  assert_alias_lookup mysql      srv002    acme-inc.com 172.17.1.2
+  assert_alias_lookup smtp       mail001   acme-inc.com 172.17.2.1
+  assert_alias_lookup mail-in    mail001   acme-inc.com 172.17.2.1
+  assert_alias_lookup imap       mail003   acme-inc.com 172.17.2.3
+  assert_alias_lookup mail-out   mail003   acme-inc.com 172.17.2.3
+
+}
+
+@test "IPv6 forward lookups acme-inc.com" {
+  #                          hostname domain       IPv6
+  assert_forward_ipv6_lookup srv001   acme-inc.com 2001:db8::1
+  assert_forward_ipv6_lookup srv002   acme-inc.com 2001:db8::2
+  assert_forward_ipv6_lookup mail001  acme-inc.com 2001:db8::d:1
+  assert_forward_ipv6_lookup mail002  acme-inc.com 2001:db8::d:2
+  assert_forward_ipv6_lookup mail003  acme-inc.com 2001:db8::d:3
+}
+
+@test "IPv6 reverse lookups acme-inc.com" {
+  #                          hostname domain       IPv6
+  assert_forward_ipv6_lookup srv001   acme-inc.com 2001:db8::1
+  assert_forward_ipv6_lookup srv002   acme-inc.com 2001:db8::2
+  assert_forward_ipv6_lookup mail001  acme-inc.com 2001:db8::d:1
+  assert_forward_ipv6_lookup mail002  acme-inc.com 2001:db8::d:2
+  assert_forward_ipv6_lookup mail003  acme-inc.com 2001:db8::d:3
+}
+
+@test "NS record lookup acme-inc.com" {
+  assert_ns_lookup acme-inc.com \
+    ns1.acme-inc.com \
+    ns2.acme-inc.com 
+}
+
+@test "Mail server lookup acme-inc.com" {
+  assert_mx_lookup acme-inc.com \
+                   10 mail001 \
+                   20 mail002
+}
+
+@test "Service record lookup acme-inc.com" {
+  assert_srv_lookup acme-inc.com _ldap._tcp 0 100 88 srv010
+}
+
+@test "TXT record lookup acme-inc.com" {
+  assert_txt_lookup _kerberos.acme-inc.com KERBEROS.ACME-INC.COM
+  assert_txt_lookup acme-inc.com "some text" "more text"
+}
+
+# Tests for domain example.com
+
+
+@test "Forward lookups example.com" {
+  #                     host name  domain      IP
+  assert_forward_lookup srv001     example.com 192.0.2.1
+  assert_forward_lookup srv002     example.com 192.0.2.2
+  assert_forward_lookup mail001    example.com 192.0.2.10
+}
+
+@test "Reverse lookups example.com" {
+  #                     host name  domain      IP
+  assert_reverse_lookup srv001     example.com 192.0.2.1
+  assert_reverse_lookup srv002     example.com 192.0.2.2
+  assert_reverse_lookup mail001    example.com 192.0.2.10
+}
+
+@test "Alias lookups example.com" {
+  #                   alias      hostname  domain      IP
+  assert_alias_lookup www        srv001    example.com 192.0.2.1
+}
+
+@test "IPv6 forward lookups example.com" {
+  #                          hostname domain      IPv6
+  assert_forward_ipv6_lookup srv001   example.com 2001:db9::1
+}
+
+@test "IPv6 reverse lookups example.com" {
+  #                     hostname domain      IPv6
+  assert_reverse_lookup srv001   example.com 2001:db9::1
+}
+
+@test "NS record lookup example.com" {
+  assert_ns_lookup example.com \
+    ns1.acme-inc.com \
+    ns2.acme-inc.com
+}
+
+@test "Mail server lookup example.com" {
+  assert_mx_lookup example.com \
+                   10 mail001
+}
+

--- a/molecule/default/files/functional-tests.sh
+++ b/molecule/default/files/functional-tests.sh
@@ -1,0 +1,117 @@
+#! /usr/bin/env bash
+#
+# Author:   Bert Van Vreckem <bert.vanvreckem@gmail.com>
+#
+# Run BATS test files in the current directory, and the ones in the subdirectory
+# matching the host name.
+#
+# The script installs BATS if needed. It's best to put ${bats_install_dir} in
+# your .gitignore.
+
+set -o errexit  # abort on nonzero exitstatus
+set -o nounset  # abort on unbound variable
+
+#{{{ Variables
+
+test_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+bats_archive="v0.4.0.tar.gz"
+bats_url="https://github.com/sstephenson/bats/archive/${bats_archive}"
+bats_install_dir="/opt"
+bats_default_location="${bats_install_dir}/bats/libexec/bats"
+test_file_pattern="*.bats"
+
+# Color definitions
+readonly reset='\e[0m'
+readonly black='\e[0;30m'
+readonly red='\e[0;31m'
+readonly green='\e[0;32m'
+readonly yellow='\e[0;33m'
+readonly blue='\e[0;34m'
+readonly purple='\e[0;35m'
+readonly cyan='\e[0;36m'
+readonly white='\e[0;37m'
+#}}}
+
+main() {
+
+  bats=$(find_bats_executable)
+
+  if [ -z "${bats}" ]; then
+    install_bats
+    bats="${bats_default_location}"
+  fi
+
+  debug "Using BATS executable at: ${bats}"
+
+  # List all test cases (i.e. files in the test dir matching the test file
+  # pattern)
+
+  # Tests to be run on all hosts
+  global_tests=$(find_tests "${test_dir}" 1)
+
+  # Tests for individual hosts
+  host_tests=$(find_tests "${test_dir}/${HOSTNAME}")
+
+  # Loop over test files
+  for test_case in ${global_tests} ${host_tests}; do
+    info "Running test ${test_case}"
+    ${bats} "${test_case}"
+  done
+}
+
+#{{{ Functions
+
+# Tries to find BATS executable in the PATH or the place where this script
+# installs it.
+find_bats_executable() {
+  if which bats > /dev/null;  then
+    which bats
+  elif [ -x "${bats_default_location}" ]; then
+    echo "${bats_default_location}"
+  else
+    echo ""
+  fi
+}
+
+# Usage: install_bats
+install_bats() {
+  pushd "${bats_install_dir}" > /dev/null 2>&1
+  curl --location --remote-name "${bats_url}"
+  tar xzf "${bats_archive}"
+  mv bats-* bats
+  rm "${bats_archive}"
+  popd > /dev/null 2>&1
+}
+
+# Usage: find_tests DIR [MAX_DEPTH]
+#
+# Finds BATS test suites in the specified directory
+find_tests() {
+  local max_depth=""
+  if [ "$#" -eq "2" ]; then
+    max_depth="-maxdepth $2"
+  fi
+
+  local tests
+  tests=$(find "$1" ${max_depth} -type f -name "${test_file_pattern}" -printf '%p\n' 2> /dev/null)
+
+  echo "${tests}"
+}
+
+# Usage: info [ARG]...
+#
+# Prints all arguments on the standard output stream
+info() {
+  printf "${yellow}### %s${reset}\n" "${*}"
+}
+
+# Usage: debug [ARG]...
+#
+# Prints all arguments on the standard output stream
+debug() {
+  printf "${cyan}### %s${reset}\n" "${*}"
+}
+#}}}
+
+main

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,48 @@
+---
+#
+# Molecule leverages Ansible's docker_container module by mapping
+# the values from molecule.yml to create.yml and destroy.yml.
+# More options can be found here: https://molecule.readthedocs.io/en/latest/configuration.html
+#
+
+
+
+
+dependency:
+  name: galaxy
+driver:
+  #Specifies the driver that should be used. Podman should also work
+  name: docker
+platforms:
+  #Set name and hostname
+  - name: ns1
+    hostname: ns1
+    #Specify which image should be used. Geerlingguys images are Ansible compatible and have Systemd installed
+    image: "geerlingguy/docker-centos7-ansible:latest"
+    #Command to execute when the container starts
+    command: "/usr/sbin/init"
+    #Volumes to mount within the container. Important to enable systemd
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    #Give extended privileges to the container. Necessary for Systemd to operate within the container. 
+    # DO NOT use extended privileges in a production environment!
+    privileged: true
+    #Allocate pseudo-TTY
+    tty: True
+    environment:
+      container: docker
+  - name: ns2
+    hostname: ns2
+    image: "geerlingguy/docker-centos7-ansible:latest"
+    command: "/usr/sbin/init"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    privileged: true
+    tty: True 
+    environment:
+      container: docker
+provisioner:
+  name: ansible
+#Runs the verify.yml playbook. Testinfra is also a supported method. Check the Molecule documention for more information. 
+verifier:
+  name: ansible

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -18,9 +18,9 @@ platforms:
   - name: ns1
     hostname: ns1
     #Specify which image should be used. Geerlingguys images are Ansible compatible and have Systemd installed
-    image: "geerlingguy/docker-centos7-ansible:latest"
+    image: "geerlingguy/docker-ubuntu1804-ansible:latest"
     #Command to execute when the container starts
-    command: "/usr/sbin/init"
+    command: ""
     #Volumes to mount within the container. Important to enable systemd
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -33,6 +33,17 @@ platforms:
       container: docker
   - name: ns2
     hostname: ns2
+    image: "geerlingguy/docker-debian9-ansible:latest"
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    privileged: true
+    tty: True 
+    environment:
+      container: docker
+
+  - name: ns3
+    hostname: ns3
     image: "geerlingguy/docker-centos7-ansible:latest"
     command: "/usr/sbin/init"
     volumes:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -18,9 +18,9 @@ platforms:
   - name: ns1
     hostname: ns1
     #Specify which image should be used. Geerlingguys images are Ansible compatible and have Systemd installed
-    image: "geerlingguy/docker-${DISTRIBUTION}${VERSION}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
     #Command to execute when the container starts
-    command: ""
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
     #Volumes to mount within the container. Important to enable systemd
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -31,16 +31,19 @@ platforms:
     tty: True
     environment:
       container: docker
+    pre_build_image: true
+
   - name: ns2
     hostname: ns2
-    image: "geerlingguy/docker-${DISTRIBUTION}${VERSION}-ansible:latest"
-    command: ""
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true
     tty: True 
     environment:
       container: docker
+    pre_build_image: true
 provisioner:
   name: ansible
 #Runs the verify.yml playbook. Testinfra is also a supported method. Check the Molecule documention for more information. 

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -31,7 +31,6 @@ platforms:
     tty: True
     environment:
       container: docker
-    pre_build_image: true
 
   - name: ns2
     hostname: ns2
@@ -43,7 +42,6 @@ platforms:
     tty: True 
     environment:
       container: docker
-    pre_build_image: true
 provisioner:
   name: ansible
 #Runs the verify.yml playbook. Testinfra is also a supported method. Check the Molecule documention for more information. 

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -18,7 +18,7 @@ platforms:
   - name: ns1
     hostname: ns1
     #Specify which image should be used. Geerlingguys images are Ansible compatible and have Systemd installed
-    image: "geerlingguy/docker-ubuntu1804-ansible:latest"
+    image: "geerlingguy/docker-${DISTRIBUTION}${VERSION}-ansible:latest"
     #Command to execute when the container starts
     command: ""
     #Volumes to mount within the container. Important to enable systemd
@@ -33,19 +33,8 @@ platforms:
       container: docker
   - name: ns2
     hostname: ns2
-    image: "geerlingguy/docker-debian9-ansible:latest"
+    image: "geerlingguy/docker-${DISTRIBUTION}${VERSION}-ansible:latest"
     command: ""
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    privileged: true
-    tty: True 
-    environment:
-      container: docker
-
-  - name: ns3
-    hostname: ns3
-    image: "geerlingguy/docker-centos7-ansible:latest"
-    command: "/usr/sbin/init"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     privileged: true

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -23,11 +23,6 @@
     register: shell_result2
     when: ansible_facts['hostname'] == 'ns2' 
 
-  - name: "Run test bats against NS3"
-    shell: SUT_IP=172.17.0.4 /functional-tests.sh
-    register: shell_result3
-    when: ansible_facts['hostname'] == 'ns3' 
-
   - name: "Display bats results of NS1"
     debug:
       var: shell_result.stdout_lines
@@ -36,7 +31,4 @@
     debug:
       var: shell_result2.stdout_lines
 
-  - name: "Display bats results of NS3"
-    debug:
-      var: shell_result3.stdout_lines
 

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -23,6 +23,10 @@
     register: shell_result2
     when: ansible_facts['hostname'] == 'ns2' 
 
+  - name: "Run test bats against NS3"
+    shell: SUT_IP=172.17.0.4 /functional-tests.sh
+    register: shell_result3
+    when: ansible_facts['hostname'] == 'ns3' 
 
   - name: "Display bats results of NS1"
     debug:
@@ -31,4 +35,8 @@
   - name: "Display bats results of NS2"
     debug:
       var: shell_result2.stdout_lines
+
+  - name: "Display bats results of NS3"
+    debug:
+      var: shell_result3.stdout_lines
 

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -5,10 +5,22 @@
   become: true
   hosts: all
   tasks:
-  - name: "Run test bats"
+  - name: "Run test bats against NS1"
     shell: SUT_IP=172.17.0.2 /functional-tests.sh
     register: shell_result
-  
-  - name: "Display bats results"
+    when: ansible_facts['hostname'] == 'ns1'
+
+  - name: "Run test bats against NS2"
+    shell: SUT_IP=172.17.0.3 /functional-tests.sh
+    register: shell_result2
+    when: ansible_facts['hostname'] == 'ns2' 
+
+
+  - name: "Display bats results of NS1"
     debug:
       var: shell_result.stdout_lines
+
+  - name: "Display bats results of NS2"
+    debug:
+      var: shell_result2.stdout_lines
+

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -5,6 +5,14 @@
   become: true
   hosts: all
   tasks:
+
+  - name: "Ensure dnsutils and curl is present on the system"
+    apt:
+      pkg:
+        - dnsutils
+        - curl
+    when: ansible_facts['os_family'] == 'Debian'
+
   - name: "Run test bats against NS1"
     shell: SUT_IP=172.17.0.2 /functional-tests.sh
     register: shell_result

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,14 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  become: true
+  hosts: all
+  tasks:
+  - name: "Run test bats"
+    shell: SUT_IP=172.17.0.2 /functional-tests.sh
+    register: shell_result
+  
+  - name: "Display bats results"
+    debug:
+      var: shell_result.stdout_lines


### PR DESCRIPTION
### Abstract
  
Instead of complex scripts in order to create Docker containers, Molecule allows developers to easily and quickly test their roles  by automatically creating containers which are configured by readable yaml configuration files. Molecule does this by leveraging Ansible's [docker_container](https://docs.ansible.com/ansible/latest/modules/docker_container_module.html) module. 

The proposed Molecule configuration is essentially the automated version of the docker_tests branch, all done with a single command! An example of a working .travis.yml file is also provided. 

In **molecule.yml**, two Centos 7 containers are defined which will fulfill the master and slave role. The images are specifically chosen as they are Ansible compatible and can run systemd in them. Any Ansible/Systemd compatible image that is also supported by this role should be able to run with Molecule. 

**converge.yml** holds the the testing variables as well as two tasks which will transfer the automated acceptance tests to the containers. These two files are located under `molecule/default/files`

**verify.yml** is the playbook that will launch the automated tests. 

### Requirements and installation

1. Docker should be present on the system.
2. As recommended by the [Molecule documentation](https://molecule.readthedocs.io/en/latest/index.html), a Python virtual environment is highly recommended
3. Install Molecule, the Docker driver and python-netaddr with `python3 -m pip install molecule docker netaddr`. 
4. Verify that Molecule is installed with either `molecule --version` or `molecule --help`

### Testing procedure

1. Clone the repo
2. Navigate to the root of the role
3. Run `molecule test`

The Molecule test command will **always** destroy the containers at the end of the testing procedure. For development purposes, use `molecule converge` instead since it will keep the containers alive. `molecule login` also allows access to the container through an interactive shell.  

`molecule verify` can at any time be run in a converged state to verify that BIND is working. 

**Note**: this configuration, specifically the automated acceptance tests, assumes that the default Docker bridge network is being used. This means that NS1 should receive 172.17.0.2 as IPv4 while NS2 receives 172.17.0.3. If you receive errors during the verify stage, you might need to change the **verify.yml* playbook according to your network setup. 