### PR TITLE
New feature: sign zones with TSIG key for XFR

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Variables are not required, unless specified.
 | `bind_recursion`             | `false`              | Determines whether requests for which the DNS server is not authoritative should be forwarded†.                              |
 | `bind_rrset_order`           | `random`             | Defines order for DNS round robin (either `random` or `cyclic`)                                                              |
 | `bind_statistcs_channels`    | `false`              | if `true`, BIND is configured with a statistics_channels clause (currently only supports a single inet)                      |
+| `bind_transfer_key_name`     | -                    | The name of a TSIG key that should be used to sign XFR requests from the client                                              |
 | `bind_zone_dir`              | -                    | When defined, sets a custom absolute path to the server directory (for zone files, etc.) instead of the default.             |
 | `bind_zone_domains`          | n/a                  | A list of domains to configure, with a separate dict for each domain, with relevant details                                  |
 | `- allow_update`             | `['none']`           | A list of hosts that are allowed to dynamically update this DNS zone.                                                        |
@@ -223,6 +224,16 @@ bind_extra_include_files:
 
 This will be set in a file *"{{ bind_auth_file }}* (e.g. /etc/bind/auth_transfer.conf for debian) which have to be added in the list variable **bind_extra_include_files**
 
+### Using TSIG for zone transfer (XFR) authorization
+
+To authorize the transfer of zone between master & slave based on a TSIG key, set the name in the variable `bind_transfer_key_name`:
+
+```Yaml
+bind_transfer_key_name: master_key
+```
+
+A check will be performed to ensure the key is actually present in the `bind_dns_keys` dictionary. This will add a server statement for the `bind_zone_master_ip` in `bind_auth_file` on a slave containing the specified key.
+
 ## Dependencies
 
 No dependencies.
@@ -326,3 +337,4 @@ Contributors:
 - [Robin Ophalvens](https://github.com/RobinOphalvens)
 - [Romuald](https://github.com/rds13)
 - [Tom Meinlschmidt](https://github.com/tmeinlschmidt)
+- [Jascha Sticher](https://github.com/itbane)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,11 @@
   assert:
     that: bind_zone_master_server_ip is defined
 
+- name: Check that transfer key exists in keys list
+  assert:
+    that: bind_dns_keys | selectattr("name",'equalto',"{{bind_transfer_key_name}}") | list | count > 0
+  when: bind_transfer_key_name is defined and bind_transfer_key_name | length > 0
+
 - name: Install BIND
   package:
     pkg: "{{ item }}"

--- a/templates/auth_transfer.j2
+++ b/templates/auth_transfer.j2
@@ -1,4 +1,9 @@
+{% if bind_transfer_key_name is defined and bind_zone_master_server_ip not in ansible_all_ipv4_addresses %}
+server {{ bind_zone_master_server_ip }} {
+  keys { {{ bind_transfer_key_name }}; };
+};
 
+{% endif %}
 server {{ ansible_default_ipv4.address }} {
   keys { {% for mykey in bind_dns_keys %} {{ mykey.name }}; {% endfor %} };
 };


### PR DESCRIPTION
Hi,

it would be a great feature to let one use a defined TSIG key to sign zone transfer reuqests, especially in environments where you do not control the master node yourself. This allows the other side to not use the servers IP for athorization but the TSIG key.

At the moment, all defined TSIG keys (`bind_dns_keys`) are only used locally.

The proposed feature adds another variable, `bind_transfer_key_name`. If set, this variable will add a server statement to <confdir>/auth_transfer.conf that tells bind to sign all requests to `bind_zone_master_ip` with said TSIG key.

Before changing any configuration, a check is performed if the supplied transfer key is present in the `bind_dns_keys` dict. This check is case sensitive, as it is in bind9 itself.

The change only affects slave nodes, as you can already add the key the allow-* statements.

Let me know if I should add something else or missed something.

KR, Jascha