### PR TITLE
Add dns64 option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Variables are not required, unless specified.
 | `bind_allow_query`           | `['localhost']`      | A list of hosts that are allowed to query this DNS server. Set to ['any'] to allow all hosts                                 |
 | `bind_allow_recursion`       | `['any']`            | Similar to bind_allow_query, this option applies to recursive queries.                                                       |
 | `bind_check_names`           | `[]`                 | Check host names for compliance with RFC 952 and RFC 1123 and take the defined action (e.g. `warn`, `ignore`, `fail`).       |
+| `bind_dns64`                 | -                    | DNS64 option                                                                                                                 |
+| `bind_dns64_clients`         | `any;`               | Default DNSS64 client ACL                                                                                                    |
 | `bind_dns_keys`              | `[]`                 | A list of binding keys, which are dicts with fields `name` `algorithm` and `secret`. See below for an example.               |
 | `bind_dnssec_enable`         | `true`               | Is DNSSEC enabled                                                                                                            |
 | `bind_dnssec_validation`     | `true`               | Is DNSSEC validation enabled                                                                                                 |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -68,3 +68,6 @@ bind_zone_minimum_ttl: "1D"
 
 # File mode for master zone files (needs to be something like 0660 for dynamic updates)
 bind_zone_file_mode: "0640"
+
+# Default ACL for DNS64
+bind_dns64_clients: "any;"

--- a/templates/master_etc_named.conf.j2
+++ b/templates/master_etc_named.conf.j2
@@ -48,6 +48,11 @@ options {
 
   querylog yes;
 {% endif %}
+{% if bind_dns64 is defined %}
+  dns64 64:ff9b::/96 {
+    clients { "{{ bind_dns64_clients }}" };
+  };
+{% endif %}
 };
 
 {% if bind_statistics_channels %}

--- a/templates/slave_etc_named.conf.j2
+++ b/templates/slave_etc_named.conf.j2
@@ -45,6 +45,12 @@ options {
 {% if bind_query_log is defined %}
   querylog yes;
 {% endif %}
+{% if bind_dns64 is defined %}
+
+  dns64 64:ff9b::/96 {
+    clients { "{{ bind_dns64_clients }}" };
+  };
+{% endif %}
 };
 
 {% if bind_statistics_channels %}


### PR DESCRIPTION
This will add [DNS64](https://www.oreilly.com/library/view/dns-and-bind/9781449308025/ch04.html) and DNS64 client ACL option to master and slave configs.
