### PR TITLE
Added possibility to specify several master servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Variables are not required, unless specified.
 | `- text`                     | `[]`                 | A list of dicts with fields `name` and `text`, specifying TXT records. `text` can be a list or string.                       |
 | `- naptr`                    | `[]`                 | A list of dicts with fields `name`, `order`, `pref`, `flags`, `service`, `regex` and `replacement` specifying NAPTR records. |
 | `bind_zone_file_mode`        | 0640                 | The file permissions for the main config file (named.conf)                                                                   |
-| `bind_zone_master_server_ip` | -                    | **(Required)** The IP address of the master DNS server.                                                                      |
+| `bind_zone_master_server_ips` | `[]`                 | **(Required)** The IP addresses of the master DNS servers server.                                                                      |
 | `bind_zone_minimum_ttl`      | `1D`                 | Minimum TTL field in the SOA record.                                                                                         |
 | `bind_zone_time_to_expire`   | `1W`                 | Time to expire field in the SOA record.                                                                                      |
 | `bind_zone_time_to_refresh`  | `1D`                 | Time to refresh field in the SOA record.                                                                                     |
@@ -90,7 +90,7 @@ Variables are not required, unless specified.
 
 ### Minimal variables for a working zone
 
-Even though only variable `bind_zone_master_server_ip` is required for the role to run without errors, this is not sufficient to get a working zone. In order to set up an authoritative name server that is available to clients, you should also at least define the following variables:
+Even though only variable `bind_zone_master_server_ips` is required for the role to run without errors, this is not sufficient to get a working zone. In order to set up an authoritative name server that is available to clients, you should also at least define the following variables:
 
 | Variable                     | Master | Slave |
 | :---                         | :---:  | :---: |
@@ -159,7 +159,9 @@ bind_zone_domains:
 ```Yaml
     bind_listen_ipv4: ['any']
     bind_allow_query: ['any']
-    bind_zone_master_server_ip: 192.168.111.222
+    bind_zone_master_server_ips:
+      - 192.168.111.221
+      - 192.168.111.222
     bind_zone_domains:
       - name: example.com
 ```

--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ Variables are not required, unless specified.
 | `- text`                     | `[]`                 | A list of dicts with fields `name` and `text`, specifying TXT records. `text` can be a list or string.                       |
 | `- naptr`                    | `[]`                 | A list of dicts with fields `name`, `order`, `pref`, `flags`, `service`, `regex` and `replacement` specifying NAPTR records. |
 | `bind_zone_file_mode`        | 0640                 | The file permissions for the main config file (named.conf)                                                                   |
-| `bind_zone_master_server_ips` | `[]`                 | **(Required)** The IP addresses of the master DNS servers server.                                                                      |
+| `bind_zone_master_server_ip` | -                    | Deprecated (will be removed in the future releases) The IP address of the master DNS server.                                 |
+| `bind_zone_master_server_ips`| `[]`                 | **(Required)** The IP addresses of the master DNS servers server.                                                            |
 | `bind_zone_minimum_ttl`      | `1D`                 | Minimum TTL field in the SOA record.                                                                                         |
 | `bind_zone_time_to_expire`   | `1W`                 | Time to expire field in the SOA record.                                                                                      |
 | `bind_zone_time_to_refresh`  | `1D`                 | Time to refresh field in the SOA record.                                                                                     |

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -20,7 +20,9 @@
     bind_recursion: true
     bind_query_log: 'data/query.log'
     bind_check_names: 'master ignore'
-    bind_zone_master_server_ip: 172.17.0.2
+    bind_zone_master_server_ips:
+      - 172.17.0.1
+      - 172.17.0.2
     bind_zone_minimum_ttl: "2D"
     bind_zone_ttl: "2W"
     bind_zone_time_to_refresh: "2D"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,9 +9,15 @@
     - "{{ ansible_os_family }}.yml"
   tags: bind,pretask
 
+- name: Backward compatibility between bind_zone_master_server_ip and bind_zone_master_server_ips
+  set_fact:
+    bind_zone_master_server_ips: "{{ [bind_zone_master_server_ip] }}"
+  when: bind_zone_master_server_ip is defined
+
 - name: Check whether `bind_zone_master_server_ips` was set
   assert:
     that: bind_zone_master_server_ips is defined
+
 
 - name: Install BIND
   package:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,9 +9,9 @@
     - "{{ ansible_os_family }}.yml"
   tags: bind,pretask
 
-- name: Check whether `bind_zone_master_server_ip` was set
+- name: Check whether `bind_zone_master_server_ips` was set
   assert:
-    that: bind_zone_master_server_ip is defined
+    that: bind_zone_master_server_ips is defined
 
 - name: Install BIND
   package:
@@ -55,11 +55,11 @@
 
 - name: Set up the machine as a master DNS server
   include_tasks: master.yml
-  when: bind_zone_master_server_ip in ansible_all_ipv4_addresses
+  when: ansible_all_ipv4_addresses|length > ansible_all_ipv4_addresses|difference(bind_zone_master_server_ips)|length
 
 - name: Set up the machine as a slave DNS server
   include_tasks: slave.yml
-  when: bind_zone_master_server_ip not in ansible_all_ipv4_addresses
+  when: ansible_all_ipv4_addresses|length == ansible_all_ipv4_addresses|difference(bind_zone_master_server_ips)|length
 
 - name: Start BIND service
   service:

--- a/templates/slave_etc_named.conf.j2
+++ b/templates/slave_etc_named.conf.j2
@@ -85,7 +85,11 @@ include "{{ file }}";
 {% if bind_zone.create_forward_zones is not defined or bind_zone.create_forward_zones %}
 zone "{{ bind_zone.name }}" IN {
   type slave;
-  masters { {{ bind_zone_master_server_ip }}; };
+  {% if bind_zone.masters is defined %}
+  masters { {{ bind_zone.masters | join('; ') }}; };
+  {% else %}
+  masters { {{ bind_zone_master_server_ips | join('; ') }}; };
+  {% endif %}
   file "{{ bind_slave_dir }}/{{ bind_zone.name }}";
 {% if bind_zone.delegate is defined %}
   forwarders {};
@@ -98,7 +102,11 @@ zone "{{ bind_zone.name }}" IN {
 {% for network in bind_zone.networks %}
 zone "{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr.arpa" IN {
   type slave;
-  masters { {{ bind_zone_master_server_ip }}; };
+  {% if bind_zone.masters is defined %}
+  masters { {{ bind_zone.masters | join('; ') }}; };
+  {% else %}
+  masters { {{ bind_zone_master_server_ips | join('; ') }}; };
+  {% endif %}
   file "{{ bind_slave_dir }}/{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr.arpa";
 };
 {% endfor %}
@@ -110,7 +118,11 @@ zone "{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr
 {% for network in bind_zone.ipv6_networks %}
 zone "{{ (network | ipaddr('revdns'))[-(9+(network|regex_replace('^.*/','')|int)//2):] }}" IN {
   type slave;
-  masters { {{ bind_zone_master_server_ip }}; };
+  {% if bind_zone.masters is defined %}
+  masters { {{ bind_zone.masters | join('; ') }}; };
+  {% else %}
+  masters { {{ bind_zone_master_server_ips | join('; ') }}; };
+  {% endif %}
   file "{{ bind_slave_dir }}/{{ (network | ipaddr('revdns'))[-(9+(network|regex_replace('^.*/','')|int)//2):-1] }}";
 };
 {% endfor %}


### PR DESCRIPTION
Added possibility to specify several master servers.
Example:
```
bind_zone_master_server_ips:
    - 172.17.0.1
    - 172.17.0.2
```

Previously can be specified single master server in the variable `bind_zone_master_server_ip`. If one of zone need different masters it was impossible to change it.
Therefore, added possibility to redefine masters for specific zone.
Example:
```
bind_zone_domains:
    - name: example.com
      masters:
          - 172.17.20.2
          - 172.17.20.3
```