### PR TITLE
Allow to create slave zone on master NS server

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Variables are not required, unless specified.
 | `- mail_servers`             | `[]`                 | A list of dicts (with fields `name` and `preference`) specifying the mail servers for this domain.                           |
 | `- name_servers`             | `[ansible_hostname]` | A list of the DNS servers for this domain.                                                                                   |
 | `- name`                     | `example.com`        | The domain name                                                                                                              |
+| `- slave_only`               | `false`              | Variable that indicate that zone should be created as slave on master server.                                                |
 | `- networks`                 | `['10.0.2']`         | A list of the networks that are part of the domain                                                                           |
 | `- other_name_servers`       | `[]`                 | A list of the DNS servers outside of this domain.                                                                            |
 | `- services`                 | `[]`                 | A list of services to be advertised by SRV records                                                                           |

--- a/templates/master_etc_named.conf.j2
+++ b/templates/master_etc_named.conf.j2
@@ -96,7 +96,7 @@ include "{{ file }}";
 
 {% if bind_zone_domains is defined %}
 {% for bind_zone in bind_zone_domains %}
-{% if bind_zone.create_forward_zones is not defined or bind_zone.create_forward_zones %}
+{% if (bind_zone.create_forward_zones is not defined or bind_zone.create_forward_zones) and (bind_zone.slave_only is not defined or not bind_zone.slave_only) %}
 zone "{{ bind_zone.name }}" IN {
   type master;
   file "{{ bind_zone_dir }}/{{ bind_zone.name }}";
@@ -109,6 +109,19 @@ zone "{{ bind_zone.name }}" IN {
 {% else %}
   allow-update { none; };
 {% endif %}
+{% if bind_zone.delegate is defined %}
+  forwarders {};
+{% endif %}
+};
+{% elif (bind_zone.create_forward_zones is not defined or bind_zone.create_forward_zones) and (bind_zone.slave_only is defined and bind_zone.slave_only) %}
+zone "{{ bind_zone.name }}" IN {
+  type slave;
+  {% if bind_zone.masters is defined %}
+  masters { {{ bind_zone.masters | join('; ') }}; };
+  {% else %}
+  masters { {{ bind_zone_master_server_ips | join('; ') }}; };
+  {% endif %}
+  file "{{ bind_slave_dir }}/{{ bind_zone.name }}";
 {% if bind_zone.delegate is defined %}
   forwarders {};
 {% endif %}


### PR DESCRIPTION
Sometime, master server should have slave zones, which replicated from third party NS servers.
This commit add new variable - slave_only. It will allow to create slave zone on master NS server.