### PR TITLE
Relates to #135. Specify molecule version explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install molecule yamllint ansible-lint docker netaddr dnspython
+        run: pip3 install molecule==3.0.8 yamllint ansible-lint docker netaddr dnspython
 
       - name: Run Molecule Primary/Secondary/Forwarder tests
         run: molecule test


### PR DESCRIPTION
Following upgrade of upstream molecule to 3.1.1, current molecule configuration breaks.
Specify molecule version explicitly (3.0.8), till we have a working solution.