### PR TITLE
Added handling for response-policy zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The packages `python-netaddr` (required for the [`ipaddr`](https://docs.ansible.
 | `- networks`                | `['10.0.2']`         | A list of the networks that are part of the domain                                                                                   |
 | `- other_name_servers`      | `[]`                 | A list of the DNS servers outside of this domain.                                                                                    |
 | `- primaries`               | -                    | A list of primary DNS servers for this zone.                                                                                         |
+| `- rpz`                     | `false`              | Whether the zone is a reponse policy zone.                                                                                           |
 | `- services`                | `[]`                 | A list of services to be advertised by SRV records                                                                                   |
 | `- text`                    | `[]`                 | A list of mappings with keys `name:` and `text:`, specifying TXT records. `text:` can be a list or string.                           |
 | `- type`                    | -                    | Optional zone type. If not specified, autodetection will be used. Possible values include `primary`, `secondary` or `forward`        |

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The packages `python-netaddr` (required for the [`ipaddr`](https://docs.ansible.
 | `- networks`                | `['10.0.2']`         | A list of the networks that are part of the domain                                                                                   |
 | `- other_name_servers`      | `[]`                 | A list of the DNS servers outside of this domain.                                                                                    |
 | `- primaries`               | -                    | A list of primary DNS servers for this zone.                                                                                         |
-| `- rpz`                     | `false`              | Whether the zone is a reponse policy zone.                                                                                           |
+| `- response_zone            | `false`              | Whether the zone is a response policy zone (https://www.isc.org/rpz/).                                                               |
 | `- services`                | `[]`                 | A list of services to be advertised by SRV records                                                                                   |
 | `- text`                    | `[]`                 | A list of mappings with keys `name:` and `text:`, specifying TXT records. `text:` can be a list or string.                           |
 | `- type`                    | -                    | Optional zone type. If not specified, autodetection will be used. Possible values include `primary`, `secondary` or `forward`        |

--- a/molecule/shared_inventory/group_vars/all.yml
+++ b/molecule/shared_inventory/group_vars/all.yml
@@ -117,3 +117,21 @@ bind_zones:
         text:
           - 'some text'
           - 'more text'
+  - name: 'rpz'
+    create_reverse_zones: false
+    primaries:
+      - '{{ ansible_default_ipv4.address }}'
+    networks:
+      - '192.0.2'
+    ipv6_networks:
+      - '2001:db9::/48'
+    name_servers:
+      - localhost.
+    hostmaster_email: admin
+    hosts:
+      - name: blackhole
+        ip: 1.2.3.4
+        ipv6: '2001:db9::99'
+      - name: blackhole.example.com
+        ip: 1.2.3.5
+        ipv6: '2001:db9::100'

--- a/molecule/shared_inventory/verify.yml
+++ b/molecule/shared_inventory/verify.yml
@@ -18,19 +18,21 @@
     - name: IPv4 Forward lookups
       assert:
         that:
-          - lookup('dig', 'ns1.acme-inc.com', local_dns )    == '10.11.0.4'
-          - lookup('dig', 'ns2.acme-inc.com', local_dns)     == '10.11.0.5'
-          - lookup('dig', 'srv001.acme-inc.com', local_dns)  == '10.11.1.1'
-          - lookup('dig', 'srv002.acme-inc.com', local_dns)  == '10.11.1.2'
-          - lookup('dig', 'mail001.acme-inc.com', local_dns) == '10.11.2.1'
-          - lookup('dig', 'mail002.acme-inc.com', local_dns) == '10.11.2.2'
-          - lookup('dig', 'mail003.acme-inc.com', local_dns) == '10.11.2.3'
-          - lookup('dig', 'srv010.acme-inc.com', local_dns)  == '10.11.0.10'
-          - lookup('dig', 'srv011.acme-inc.com', local_dns)  == '10.11.0.11'
-          - lookup('dig', 'srv012.acme-inc.com', local_dns)  == '10.11.0.12'
-          - lookup('dig', 'srv001.example.com', local_dns)   == '192.0.2.1'
-          - lookup('dig', 'srv002.example.com', local_dns)   == '192.0.2.2'
-          - lookup('dig', 'mail001.example.com', local_dns)  == '192.0.2.10'
+          - lookup('dig', 'ns1.acme-inc.com', local_dns )     == '10.11.0.4'
+          - lookup('dig', 'ns2.acme-inc.com', local_dns)      == '10.11.0.5'
+          - lookup('dig', 'srv001.acme-inc.com', local_dns)   == '10.11.1.1'
+          - lookup('dig', 'srv002.acme-inc.com', local_dns)   == '10.11.1.2'
+          - lookup('dig', 'mail001.acme-inc.com', local_dns)  == '10.11.2.1'
+          - lookup('dig', 'mail002.acme-inc.com', local_dns)  == '10.11.2.2'
+          - lookup('dig', 'mail003.acme-inc.com', local_dns)  == '10.11.2.3'
+          - lookup('dig', 'srv010.acme-inc.com', local_dns)   == '10.11.0.10'
+          - lookup('dig', 'srv011.acme-inc.com', local_dns)   == '10.11.0.11'
+          - lookup('dig', 'srv012.acme-inc.com', local_dns)   == '10.11.0.12'
+          - lookup('dig', 'srv001.example.com', local_dns)    == '192.0.2.1'
+          - lookup('dig', 'srv002.example.com', local_dns)    == '192.0.2.2'
+          - lookup('dig', 'mail001.example.com', local_dns)   == '192.0.2.10'
+          - lookup('dig', 'blackhole', local_dns)             == '1.2.3.4'
+          - lookup('dig', 'blackhole.example.com', local_dns) == '1.2.3.5'
 
     - name: IPv4 Reverse lookups
       assert:
@@ -63,12 +65,14 @@
     - name: IPv6 Forward lookups
       assert:
         that:
-          - lookup('dig', 'srv001.acme-inc.com/AAAA', local_dns)  == '2001:db8::1'
-          - lookup('dig', 'srv002.acme-inc.com/AAAA', local_dns)  == '2001:db8::2'
-          - lookup('dig', 'mail001.acme-inc.com/AAAA', local_dns) == '2001:db8::d:1'
-          - lookup('dig', 'mail002.acme-inc.com/AAAA', local_dns) == '2001:db8::d:2'
-          - lookup('dig', 'mail003.acme-inc.com/AAAA', local_dns) == '2001:db8::d:3'
-          - lookup('dig', 'srv001.example.com/AAAA', local_dns)   == '2001:db9::1'
+          - lookup('dig', 'srv001.acme-inc.com/AAAA', local_dns)   == '2001:db8::1'
+          - lookup('dig', 'srv002.acme-inc.com/AAAA', local_dns)   == '2001:db8::2'
+          - lookup('dig', 'mail001.acme-inc.com/AAAA', local_dns)  == '2001:db8::d:1'
+          - lookup('dig', 'mail002.acme-inc.com/AAAA', local_dns)  == '2001:db8::d:2'
+          - lookup('dig', 'mail003.acme-inc.com/AAAA', local_dns)  == '2001:db8::d:3'
+          - lookup('dig', 'srv001.example.com/AAAA', local_dns)    == '2001:db9::1'
+          - lookup('dig', 'blackhole/AAAA', local_dns)             == '2001:db9::99'
+          - lookup('dig', 'blackhole.example.com/AAAA', local_dns) == '2001:db9::100'
 
     - name: IPv6 Reverse lookups
       assert:

--- a/templates/bind_zone.j2
+++ b/templates/bind_zone.j2
@@ -23,7 +23,7 @@
 {% set _ = _zone_data.update({'services': item.services|default([])}) %}
 {% set _ = _zone_data.update({'text': item.text|default([])}) %}
 {% set _ = _zone_data.update({'naptr': item.naptr|default([])}) %}
-{% set rpz = true if (item.rpz is defined and item.rpz is sameas true) else false %}
+{% set _rpz = true if (item.response_zone is defined and item.response_zone is sameas true) else false %}
 {#
  #  Compare the zone file hash with the current zone data hash and set serial
  #  accordingly
@@ -44,7 +44,7 @@
 ; Zone file for {{ _zone_data['domain'] }}
 {{ ansible_managed | comment(decoration='; ') }}
 
-{% if rpz is sameas false %}
+{% if _rpz is sameas false %}
 $ORIGIN {{ _zone_data['domain'] }}.
 {% endif %}
 $TTL {{ _zone_data['ttl'] }}

--- a/templates/bind_zone.j2
+++ b/templates/bind_zone.j2
@@ -23,6 +23,7 @@
 {% set _ = _zone_data.update({'services': item.services|default([])}) %}
 {% set _ = _zone_data.update({'text': item.text|default([])}) %}
 {% set _ = _zone_data.update({'naptr': item.naptr|default([])}) %}
+{% set rpz = true if (item.rpz is defined and item.rpz is sameas true) else false %}
 {#
  #  Compare the zone file hash with the current zone data hash and set serial
  #  accordingly
@@ -43,7 +44,9 @@
 ; Zone file for {{ _zone_data['domain'] }}
 {{ ansible_managed | comment(decoration='; ') }}
 
+{% if rpz is sameas false %}
 $ORIGIN {{ _zone_data['domain'] }}.
+{% endif %}
 $TTL {{ _zone_data['ttl'] }}
 
 {% if _zone_data['mname']|length > 0 %}

--- a/templates/etc_named.conf.j2
+++ b/templates/etc_named.conf.j2
@@ -38,9 +38,9 @@ options {
 
   rrset-order { order {{ bind_rrset_order }}; };
 
-{% if bind_zones | selectattr('rpz', 'defined') | selectattr('rpz', 'equalto', true) | list | length > 0 %}
+{% if bind_zones | selectattr('response_zone', 'defined') | selectattr('response_zone', 'equalto', true) | list | length > 0 %}
   response-policy {
-{% for zone in bind_zones | selectattr('rpz', 'defined') | selectattr('rpz', 'equalto', true) | list %}
+{% for zone in bind_zones | selectattr('response_zone', 'defined') | selectattr('response_zone', 'equalto', true) | list %}
     zone "{{ zone.name }}";
 {% endfor %}
   };

--- a/templates/etc_named.conf.j2
+++ b/templates/etc_named.conf.j2
@@ -38,6 +38,14 @@ options {
 
   rrset-order { order {{ bind_rrset_order }}; };
 
+{% if bind_zones | selectattr('rpz', 'defined') | selectattr('rpz', 'equalto', true) | list | length > 0 %}
+  response-policy {
+{% for zone in bind_zones | selectattr('rpz', 'defined') | selectattr('rpz', 'equalto', true) | list %}
+    zone "{{ zone.name }}";
+{% endfor %}
+  };
+{% endif %}
+
   dnssec-enable {{ bind_dnssec_enable }};
   dnssec-validation {{ bind_dnssec_validation }};
 


### PR DESCRIPTION
I needed to create a response policy zone so I've cobbled this PR together to handle my use case but it likely needs some tweaks.

The basic idea is that response policy zones are handled like any other zone, except that they don't have $ORIGIN declared in the zone file and there is a response-policy stanza that needs to be included in the named.conf file.

The way I'm using this is to add a zone to the bind_zones variable like the below.  I'm using this to override qualified and unqualified hostnames like example.com and bob respectively.

```
bind_zones:
- name: rpz
  rpz: true
  create_reverse_zones: false
  primaries:
  - {{ ansible_default_ipv4.address }}
  name_servers:
  - localhost
  networks:
  - '192.168'
  hostmaster_email: admin
  hosts:
  - name: localhost
    ip: 127.0.0.1
  - name: bob
    ip: 192.168.150.3
  - name: example.com
    ip: 127.0.0.1
```
