### PR TITLE
Fixed config template for bind9 16

### DIFF
--- a/templates/etc_named.conf.j2
+++ b/templates/etc_named.conf.j2
@@ -38,7 +38,7 @@ options {
 
   rrset-order { order {{ bind_rrset_order }}; };
 
-  dnssec-enable {{ bind_dnssec_enable }};
+{% if bind_dnssec_enable %}  dnssec-enable {{ bind_dnssec_enable }};{% endif %}
   dnssec-validation {{ bind_dnssec_validation }};
 
   /* Path to ISC DLV key */


### PR DESCRIPTION
Hi,
in bind9.16, there are some changes to the config file.

One breaking change for this module is the removal of `dnssec-enable` - the config parser throws an error about the parameter.

This patch removes this config parameter if it is unset. To unset it, add

`bind_dnssec_enable: ~`

There are additional changes, documented [here](http://ddiguru.com/blog/bind-9-16-release-info).

A suggested update for the defaults would be setting `bind_dnssec_validation` to `auto`, as a specific trust anchor is required if set to `true` (current default).

Kind regards