### PR TITLE
Added switch to choose python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The packages `python-netaddr` (required for the [`ipaddr`](https://docs.ansible.
 | `bind_zone_time_to_refresh` | `1D`                 | Time to refresh field in the SOA record.                                                                                             |
 | `bind_zone_time_to_retry`   | `1H`                 | Time to retry field in the SOA record.                                                                                               |
 | `bind_zone_ttl`             | `1W`                 | Time to Live field in the SOA record.                                                                                                |
+| `bind_python_version`       | Depends on Distro, either `2` or `3`  |  The python version that should be used for ansible. Defaults to the OS standard |
 
 † Best practice for an authoritative name server is to leave recursion turned off. However, [for some cases](http://www.zytrax.com/books/dns/ch7/queries.html#allow-query-cache) it may be necessary to have recursion turned on.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,7 @@
 ---
 
+bind_python_version: "{{ bind_default_python_version }}"
+
 bind_log: "data/named.run"
 
 bind_zones:

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,9 +1,9 @@
 # Distro specific variables for Debian
 ---
-
+bind_default_python_version: '3'
 bind_packages:
-  - python-netaddr
-  - python-dnspython
+  - "{{ ( bind_python_version == '3' ) | ternary( 'python3-netaddr', 'python-netaddr' ) }}"
+  - "{{ ( bind_python_version == '3' ) | ternary( 'python3-dnspython', 'python-dnspython' ) }}"
   - bind9
   - bind9utils
 

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,9 +1,9 @@
 # Distro specific variables for RedHat
 ---
-
+bind_default_python_version: "{{ ( ansible_distribution_major_version == '8' ) | ternary( '3', '2' ) }}"
 bind_packages:
-  - "{{ ( ansible_distribution_major_version == '8' ) | ternary( 'python3-netaddr', 'python-netaddr' ) }}"
-  - "{{ ( ansible_distribution_major_version == '8' ) | ternary( 'python3-dns', 'python-dns' ) }}"
+  - "{{ ( bind_python_version == '3' ) | ternary( 'python3-netaddr', 'python-netaddr' ) }}"
+  - "{{ ( bind_python_version == '3' ) | ternary( 'python3-dns', 'python-dns' ) }}"
   - bind
   - bind-utils
 


### PR DESCRIPTION
Hi,
this change allows users of the role to use python3 instead of python2.
It introduces the `bind_python_version`. Its defaults are taken over from the defaults formerly used (in RedHat and Debian).

Kind regards