### PR TITLE
configure TSIG keys for notify/update queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ The packages `python-netaddr` (required for the [`ipaddr`](https://docs.ansible.
 | `bind_statistics_allow`     | `['127.0.0.1']`      | A list of hosts that can access the server statistics                                                                                |
 | `bind_statistics_host`      | `127.0.0.1`          | IP address of the network interface that the statistics service should listen on                                                     |
 | `bind_statistics_port`      | 8053                 | Network port that the statistics service should listen on                                                                            |
-| `bind_transfer_key_name`    | -                    | The name of a TSIG key that should be used to sign XFR requests from the client                                                      |
 | `bind_zone_dir`             | -                    | When defined, sets a custom absolute path to the server directory (for zone files, etc.) instead of the default.                     |
+| `bind_key_mapping`      | []                   | `Primary: Keyname` - mapping of TSIG keys to use for a specific primary |
 | `bind_zones`                | n/a                  | A list of mappings with zone definitions. See below this table for examples                                                          |
 | `- allow_update`            | `['none']`           | A list of hosts that are allowed to dynamically update this DNS zone.                                                                |
 | `- also_notify`             | -                    | A list of servers that will receive a notification when the primary zone file is reloaded.                                           |
@@ -280,13 +280,14 @@ This will be set in a file *"{{ bind_auth_file }}* (e.g. /etc/bind/auth_transfer
 
 ### Using TSIG for zone transfer (XFR) authorization
 
-**Warning:** this functionality is **broken** in v5.0.0
-
-To authorize the transfer of zone between primary & secondary servers based on a TSIG key, set the name in the variable `bind_transfer_key_name`:
+To authorize the transfer of zone between primary & secondary servers based on a TSIG key, set the mapping in the variable `bind_key_mapping`:
 
 ```Yaml
-bind_transfer_key_name: primary_key
+bind_key_mapping:
+  primary_ip: TSIG-keyname
 ```
+
+Each primary can only have one key (per view).
 
 A check will be performed to ensure the key is actually present in the `bind_dns_keys` mapping. This will add a server statement for the `a` in `bind_auth_file` on a secondary server containing the specified key.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,9 @@ bind_listen_ipv6_port:
 bind_allow_query:
   - "localhost"
 
+# A key-value list mapping server-IPs to TSIG keys for signing requests
+bind_key_mapping: {}
+
 # Determines whether recursion should be allowed. Typically, an authoritative
 # name server should have recursion turned OFF.
 bind_recursion: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,11 +27,11 @@
   when: ansible_os_family == 'Debian'
   tags: bind
 
-- name: Check that transfer key exists in keys list
+- name: Assert that all XFR keys exist in the key list
   assert:
-    that: bind_dns_keys | selectattr("name",'equalto',"{{ bind_transfer_key_name }}") | list | count > 0
-  when: bind_transfer_key_name is defined and bind_transfer_key_name | length > 0
-  tags: bind
+    that: bind_dns_keys | selectattr("name","equalto",bind_key_mapping[item]) | list | count > 0
+  loop: "{{ bind_key_mapping.keys() }}"
+  when: bind_key_mapping | list | count > 0
 
 - name: Install BIND
   package:
@@ -85,6 +85,7 @@
     group: "{{ bind_group }}"
   become: yes
   when: bind_dns_keys is defined and bind_dns_keys|length > 0
+  notify: reload bind
   tags: bind
 
 - name: Configure zones

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,7 +30,7 @@
 - name: Assert that all XFR keys exist in the key list
   assert:
     that: bind_dns_keys | selectattr("name","equalto",bind_key_mapping[item]) | list | count > 0
-  loop: "{{ bind_key_mapping.keys() }}"
+  loop: "{{ bind_key_mapping.keys() | list }}"
   when: bind_key_mapping | list | count > 0
 
 - name: Install BIND

--- a/templates/auth_transfer.j2
+++ b/templates/auth_transfer.j2
@@ -1,7 +1,10 @@
-{% if bind_transfer_key_name is defined and bind_zone_primary_server_ip not in ansible_all_ipv4_addresses %}
-server {{ bind_zone_primary_server_ip }} {
-  keys { {{ bind_transfer_key_name }}; };
+// {{ ansible_managed }}
+{% if bind_key_mapping | length > 0 %}
+{% for primary in bind_key_mapping.keys() %}
+server {{ primary }} {
+  keys { {{ bind_key_mapping[primary] }}; };
 };
+{% endfor %}
 
 {% endif %}
 server {{ ansible_default_ipv4.address }} {


### PR DESCRIPTION
Hi,

this is the v5 update for #121 .

A dictionary has been added, 'bind_key_mapping' to map hosts (primaries or secondaries - doesn't matter) to TSIG keys.

Kind regards