### PR TITLE
Fix Jinja block indent in querylog

### DIFF
--- a/templates/etc_named.conf.j2
+++ b/templates/etc_named.conf.j2
@@ -73,11 +73,11 @@ logging {
   };
 {% if bind_query_log is defined %}
   channel querylog {
-    {% if bind_query_log.file is defined %}
-      file "{{ bind_query_log.file }}" versions {{ bind_query_log.versions }} size {{ bind_query_log.size }};
-    {% else %}
-      file "{{ bind_query_log }}" versions 600 size 20m;
-    {% endif %}
+{% if bind_query_log.file is defined %}
+    file "{{ bind_query_log.file }}" versions {{ bind_query_log.versions }} size {{ bind_query_log.size }};
+{% else %}
+    file "{{ bind_query_log }}" versions 600 size 20m;
+{% endif %}
     severity dynamic;
     print-time yes;
   };


### PR DESCRIPTION
Hi,

I've noticed a cosmetic bug regarding Jinja if-block indents in [named.conf template](https://github.com/bertvv/ansible-role-bind/blob/master/templates/etc_named.conf.j2)

This PR is just to fix the indents to make the block statements nicely aligned.

Example before:
```
logging {
  channel default_debug {
    file "data/named.run";
    severity dynamic;
    print-time yes;
  };
  channel querylog {
          file "data/query.log" versions 10 size 10m;
        severity dynamic;
    print-time yes;
  };
  category queries { querylog; };
};
```

Example after:
```
logging {
  channel default_debug {
    file "data/named.run";
    severity dynamic;
    print-time yes;
  };
  channel querylog {
    file "data/query.log" versions 10 size 10m;
    severity dynamic;
    print-time yes;
  };
  category queries { querylog; };
};
```

This is actually my first PR, so hopefully I'm not disregarding some rules of how the PR should look...

Thanks.