### PR TITLE
Adding support for syslog logs

### DIFF
--- a/templates/etc_named.conf.j2
+++ b/templates/etc_named.conf.j2
@@ -87,7 +87,11 @@ logging {
 
 {% for log in bind_other_logs %}
   channel {{ log.name }} {
-    file "{{ log.file }}" versions {{ log.versions }} size {{ log.size }};
+    {% if log.file is defined %}
+      file "{{ log.file }}" versions {{ log.versions }} size {{ log.size }};
+    {% elif log.facility is defined %}
+      syslog {{ log.facility }};
+    {% endif %}
     severity dynamic;
     print-time yes;
   };


### PR DESCRIPTION
Added support to log on syslog for different type of information.

Configuraiton example

```
bind_other_logs:
  - name: "queries"
    facility: "local0"
  - name: "notify"
    facility: "local3"
```