### PR TITLE
corrected regex, so that IPv6 reverse DNS entries get created correctly

### DIFF
--- a/templates/reverse_zone_ipv6.j2
+++ b/templates/reverse_zone_ipv6.j2
@@ -17,7 +17,7 @@
 {% set _ = _zone_data.update({'retry': bind_zone_time_to_retry}) %}
 {% set _ = _zone_data.update({'expire': bind_zone_time_to_expire}) %}
 {% set _ = _zone_data.update({'minimum': bind_zone_minimum_ttl}) %}
-{% set _ = _zone_data.update({'hosts': item.0.hosts|default([]) | selectattr('ipv6','defined') | selectattr('ipv6','string') | selectattr('ipv6', 'search', '^'+item.1|regex_replace('/.*$','')) | list }) %}
+{% set _ = _zone_data.update({'hosts': item.0.hosts|default([]) | selectattr('ipv6','defined') | selectattr('ipv6','string') | selectattr('ipv6', 'search', '^'+item.1|regex_replace(':\/.*$','')) | list }) %}
 {% set _ = _zone_data.update({'revip': (item.1 | ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):] }) %}
 {#
  #  Compare the zone file hash with the current zone data hash and set serial
@@ -71,7 +71,7 @@ $ORIGIN {{ (item.1 | ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)
 {% if host.ipv6 == item.1 %}
 @                      IN  PTR  {{ host.name }}.{{ _zone_data['domain'] }}.
 {% else %}
-{% if host.ipv6 is string and host.ipv6.startswith(item.1|regex_replace('/.*$','')) %}
+{% if host.ipv6 is string and host.ipv6.startswith(item.1|regex_replace(':\/.*$','')) %}
 {% if host.name == '@' %}
 {{ host.ipv6 | ipaddr('revdns') }}{{ (host.ttl|string).rjust(6) if host.ttl is defined else ''.ljust(6) }} IN  PTR  {{ _zone_data['domain'] }}.
 {% else %}
@@ -79,7 +79,7 @@ $ORIGIN {{ (item.1 | ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)
 {% endif %}
 {% else %}
 {% for ip in host.ipv6 %}
-{% if ip.startswith(item.1|regex_replace('/.*$','')) %}
+{% if ip.startswith(item.1|regex_replace(':\/.*$','')) %}
 {{ ip | ipaddr('revdns') }}{{ (host.ttl|string).rjust(6) if host.ttl is defined else ''.ljust(6) }} IN  PTR  {{ _zone_data['domain'] }}.
 {% if host.name == '@' %}
 {% else %}


### PR DESCRIPTION
IPv6 reverse addresses did not get created due to missing escape of a forward slash and missing colon.