### PR TITLE
Add ability to omit server clause listing all keys

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,9 @@ bind_dns_keys: []
 #    algorithm: hmac-sha256
 #    secret: "azertyAZERTY123456"
 
+# Whether to include the server clause listing all keys.
+bind_dns_keys_include_server_clause: true
+
 # List of IPv4 address of the network interface(s) to listen on. Set to "any"
 # to listen on all interfaces
 bind_listen_ipv4:

--- a/templates/auth_transfer.j2
+++ b/templates/auth_transfer.j2
@@ -7,9 +7,11 @@ server {{ primary }} {
 {% endfor %}
 
 {% endif %}
+{% if bind_dns_keys_include_server_clause %}
 server {{ ansible_default_ipv4.address }} {
   keys { {% for mykey in bind_dns_keys %} {{ mykey.name }}; {% endfor %} };
 };
+{% endif %}
 
 {% for mykey in bind_dns_keys %}
 key {{ mykey.name }} {


### PR DESCRIPTION
I'm not quite sure why this server clause was put here in the first place, but it's breaking my configuration and I need to remove it.