### PR TITLE
Typo fix (remove UTF8 non-breaking spaces)

### DIFF
--- a/templates/etc_named.conf.j2
+++ b/templates/etc_named.conf.j2
@@ -38,8 +38,8 @@ options {
 
   rrset-order { order {{ bind_rrset_order }}; };
 
-{% if bind_dnssec_enable %}  dnssec-enable {{ bind_dnssec_enable }};{% endif %}
-  dnssec-validation {{ bind_dnssec_validation }};
+{% if bind_dnssec_enable %}  dnssec-enable {{ bind_dnssec_enable }};{% endif %}
+  dnssec-validation {{ bind_dnssec_validation }};
 
   /* Path to ISC DLV key */
   bindkeys-file "{{ bind_bindkeys_file }}";


### PR DESCRIPTION
I use validation tools on resulting outputs and noticed that a recent fix had (accidentally) also inserted two UTF-8  non-breaking spaces where there had previously been plain old spaces. Obviously that difference is hard to spot visually looking at the git-diffs. This just reverts that introduced typo.