### PR TITLE
Remove unnecessary extra variable

### DIFF
--- a/templates/etc_named.conf.j2
+++ b/templates/etc_named.conf.j2
@@ -107,16 +107,15 @@ include "{{ file }}";
 
 {% if bind_zone.create_forward_zones is not defined or bind_zone.create_forward_zones %}
 {# Start: set zone type  #}
-{% set _all_addresses = ansible_all_ipv4_addresses | union(ansible_all_ipv6_addresses) %}
 {% if bind_zone.type is defined and bind_zone.type == 'primary' %}
 {% set _type = 'primary' %}
 {% elif bind_zone.type is defined and bind_zone.type == 'secondary' %}
 {% set _type = 'secondary' %}
 {% elif bind_zone.type is defined and bind_zone.type == 'forward' %}
 {% set _type = 'forward' %}
-{% elif bind_zone.type is not defined and bind_zone.primaries is defined and (_all_addresses|intersect(bind_zone.primaries)|length > 0) %}
+{% elif bind_zone.type is not defined and bind_zone.primaries is defined and (host_all_addresses|intersect(bind_zone.primaries)|length > 0) %}
 {% set _type = 'primary' %}
-{% elif bind_zone.type is not defined and bind_zone.primaries is defined and not (_all_addresses|intersect(bind_zone.primaries)|length > 0) %}
+{% elif bind_zone.type is not defined and bind_zone.primaries is defined and not (host_all_addresses|intersect(bind_zone.primaries)|length > 0) %}
 {% set _type = 'secondary' %}
 {% elif bind_zone.type is not defined and bind_zone.forwarders is defined %}
 {% set _type = 'forward' %}


### PR DESCRIPTION
A variable `host_all_addresses` already exists (created in `tasks/zones.yaml`) for "the union of Ansible IPv4 and IPv6 addresses", but in `templates/etc_named.conf.j2` a temporary variable `_all_addresses` is created and used for the exact same purpose. This just removes the creation of the extra variable and changes the two places it's referenced to use the existing variable.