### PR TITLE
Add two RRL variables with zero-defaults config-handling

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,10 @@
 # List of zones for which this name server is authoritative
 bind_zones: []
 
+# Ratelimiting
+bind_rrl_responses_per_second: 0
+bind_rrl_window: 0
+
 # List of acls.
 bind_acls: []
 

--- a/templates/etc_named.conf.j2
+++ b/templates/etc_named.conf.j2
@@ -12,6 +12,16 @@ acl "{{ acl.name }}" {
 
 {% endfor %}
 options {
+{% if bind_rrl_responses_per_second is defined or bind_rrl_window is defined %}
+  rate-limit {
+{% if bind_rrl_responses_per_second is defined %}
+    responses-per-second {{ bind_rrl_responses_per_second }};
+{% endif %}
+{% if bind_rrl_window is defined %}
+    window {{ bind_rrl_window }};
+{% endif %}
+  };
+{% endif %}
 {% for port in bind_listen_ipv4_port %}
   listen-on port {{ port }} { {{ bind_listen_ipv4|join('; ') }}; };
 {% endfor %}


### PR DESCRIPTION
This adds variables for configuring two aspects of Response Rate Limiting (RRL) - "responses per second" and "window", along with defaults of "zero" which match the default state of "RRL = off".