### PR TITLE
Handle nat floatingip and handle transfer by acl and or tsig

### DIFF
--- a/tasks/zones.yml
+++ b/tasks/zones.yml
@@ -1,7 +1,10 @@
 ---
+- name: Get my public IP
+  community.general.ipify_facts:
+
 - name: Set list of all host IP addresses
   set_fact:
-    host_all_addresses: "{{ ansible_all_ipv4_addresses | union(ansible_all_ipv6_addresses) }}"
+    host_all_addresses: "{{ [ ipify_public_ip ] | union(ansible_all_ipv4_addresses | union(ansible_all_ipv6_addresses)) }}"
   tags: bind
 
 - name: Read forward zone hashes

--- a/templates/etc_named.conf.j2
+++ b/templates/etc_named.conf.j2
@@ -23,9 +23,8 @@ options {
   statistics-file "{{ bind_dir }}/data/named_stats.txt";
   memstatistics-file "{{ bind_dir }}/data/named_mem_stats.txt";
   allow-query     { {{ bind_allow_query|join('; ') }}; };
-{% if bind_acls|length != 0 %}
-  allow-transfer  { {% for acl in bind_acls %}"{{ acl.name }}"; {% endfor %}};
-{% endif %}
+  allow-transfer { none; };
+
 {% if bind_check_names is defined %}
   check-names  {{ bind_check_names }};
 {% endif %}
@@ -122,13 +121,47 @@ include "{{ file }}";
 {% set _type = 'forward' %}
 {% endif %}
 {# End: set zone type #}
+
+{# Start: set mapped primaries for the zone #}
+{% if bind_key_mapping | length != 0 %}
+{% set _mapped_zone_primaries = bind_key_mapping.keys() | intersect(bind_zone.primaries) %}
+{% else %}
+{% set _mapped_zone_primaries = [] %}
+{% endif %}
+{# End: set mapped primaries for the zone #}
+
 zone "{{ bind_zone.name }}" IN {
 {% if _type == 'primary' %}
   type master;
   file "{{ bind_zone_dir }}/{{ bind_zone.name }}";
+{% if bind_acls | length == 0 and bind_key_mapping | length == 0 %}
   notify yes;
+  allow-transfer { any; };
+{% else %}
+  notify explicit;
+  allow-transfer {
+{% if bind_acls | length != 0 %}
+{% for acl in bind_acls %}
+    {{ acl.name }};
+{% endfor %}
+{% endif %}
+{% for primary in host_all_addresses | intersect(_mapped_zone_primaries) %}
+    key {{ bind_key_mapping[primary] }};
+{% endfor %}
+  };
+{% endif %}
 {% if bind_zone.also_notify is defined %}
-  also-notify  { {{ bind_zone.also_notify|join('; ') }}; };
+  also-notify {
+{% for secondary in bind_zone.also_notify %}
+{% if host_all_addresses | intersect(_mapped_zone_primaries) | length != 0 %}
+{% for primary in host_all_addresses | intersect(_mapped_zone_primaries) %}
+    {{ secondary }} key {{ bind_key_mapping[primary] }};
+{% endfor %}
+{% else %}
+    {{ secondary }};
+{% endif %}
+{% endfor %}
+  };
 {% endif %}
 {% if bind_zone.allow_update is defined %}
   allow-update { {{ bind_zone.allow_update|join('; ') }}; };
@@ -154,9 +187,34 @@ zone "{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr
 {% if _type == 'primary' %}
   type master;
   file "{{ bind_zone_dir }}/{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr.arpa";
+{% if bind_acls | length == 0 and bind_key_mapping | length == 0 %}
   notify yes;
+  allow-transfer { any; };
+{% else %}
+  notify explicit;
+  allow-transfer {
+{% if bind_acls | length != 0 %}
+{% for acl in bind_acls %}
+    {{ acl.name }};
+{% endfor %}
+{% endif %}
+{% for primary in host_all_addresses | intersect(_mapped_zone_primaries) %}
+    key {{ bind_key_mapping[primary] }};
+{% endfor %}
+  };
+{% endif %}
 {% if bind_zone.also_notify is defined %}
-  also-notify  { {{ bind_zone.also_notify|join('; ') }}; };
+  also-notify {
+{% for secondary in bind_zone.also_notify %}
+{% if host_all_addresses | intersect(_mapped_zone_primaries) | length != 0 %}
+{% for primary in host_all_addresses | intersect(_mapped_zone_primaries) %}
+    {{ secondary }} key {{ bind_key_mapping[primary] }};
+{% endfor %}
+{% else %}
+    {{ secondary }};
+{% endif %}
+{% endfor %}
+  };
 {% endif %}
 {% if bind_zone.allow_update is defined %}
   allow-update { {{ bind_zone.allow_update|join('; ') }}; };
@@ -184,9 +242,34 @@ zone "{{ (network | ipaddr('revdns'))[-(9+(network|regex_replace('^.*/','')|int)
 {% if _type == 'primary' %}
   type master;
   file "{{ bind_zone_dir }}/{{ (network | ipaddr('revdns'))[-(9+(network|regex_replace('^.*/','')|int)//2):-1] }}";
+{% if bind_acls | length == 0 and bind_key_mapping | length == 0 %}
   notify yes;
+  allow-transfer { any; };
+{% else %}
+  notify explicit;
+  allow-transfer {
+{% if bind_acls | length != 0 %}
+{% for acl in bind_acls %}
+    {{ acl.name }};
+{% endfor %}
+{% endif %}
+{% for primary in host_all_addresses | intersect(_mapped_zone_primaries) %}
+    key {{ bind_key_mapping[primary] }};
+{% endfor %}
+  };
+{% endif %}
 {% if bind_zone.also_notify is defined %}
-  also-notify  { {{ bind_zone.also_notify|join('; ') }}; };
+  also-notify {
+{% for secondary in bind_zone.also_notify %}
+{% if host_all_addresses | intersect(_mapped_zone_primaries) | length != 0 %}
+{% for primary in host_all_addresses | intersect(_mapped_zone_primaries) %}
+    {{ secondary }} key {{ bind_key_mapping[primary] }};
+{% endfor %}
+{% else %}
+    {{ secondary }};
+{% endif %}
+{% endfor %}
+  };
 {% endif %}
 {% if bind_zone.allow_update is defined %}
   allow-update { {{ bind_zone.allow_update|join('; ') }}; };


### PR DESCRIPTION
This is two distinct changes but the second would break functionality for me (and probably many others) without applying the other before it, so I have treated them as one PR. If you still wish I separate them to two PRs anyway then let me know, but please remember they would need to be sequenced correctly if merged.

1. Use `ipify_public_ip` fact from `community.general` collection to explicitly include the public IP in `host_all_addresses` variable, because otherwise for setups routing in to a private network via a floating IP (common in clouds) or some other NAT type of solution some of the "match the primary address" logic doesn't work correctly.
2. Change the handling of variables for signed/unsigned transfer-requests (and replies) and notifications.
    1.  Existing logic configures the following:
        1. If `bind_acls` list is non-empty then at the global level allow transfer requests from each address in the list (without requiring TSIG authorization) and disallow elsewhere.
        2. If `bind_zone.also_notify` is non-empty then at the per-zone level also send *unsigned* notifications to each address in the list.
        3. Always send *unsigned* notifications to all the zone's nameservers regardless (`notify = yes`).
    2. This change configures the following (what I believe to be "defaults of least surprise while as secure as possible", but am happy to be corrected if I missed something):
        1. At the global level disallow all transfers.
        2. At the per-zone level:
            1. If `bind_acls` and `bind_key_mapping` lists are both empty then configure "no limiting" (allow transfer requests from all addresses without requiring TSIG authorization, send *unsigned* notifications to hosts listed in the `also_notify` list, and either way notify the zone's nameservers).
            2. Otherwise use `notify = explicit` (only notify addresses in the `also_notify` list, not "including the zone's nameserver either way"), and "limit the transfers" as follows:
                1. If `bind_acls` list is non-empty then allow *unsigned* transfer requests from each address in the list.
                2. For each of this zone's primaries which have a TSIG key mapped allow *signed* transfer requests from any host with the key - *as well as* unsigned transfers listed in `bind_acls`, not instead of... this is Bind's default behaviour.
                3. If `also_notify` is defined for the zone then for every secondary in `also_notify`:
                    1. Configure *signed* notifications.
                    2. Otherwise configure *unsigned* notifications.
    3. The commit looks large because the config file with this change are effectively triplicated there.