### PR TITLE
make use of bind-chroot package on EL

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -4,10 +4,10 @@ bind_default_python_version: "{{ ( ansible_distribution_major_version == '8' ) |
 bind_packages:
   - "{{ ( bind_python_version == '3' ) | ternary( 'python3-netaddr', 'python-netaddr' ) }}"
   - "{{ ( bind_python_version == '3' ) | ternary( 'python3-dns', 'python-dns' ) }}"
-  - bind
+  - bind-chroot
   - bind-utils
 
-bind_service: named
+bind_service: named-chroot
 
 # Main config file
 bind_config: /etc/named.conf


### PR DESCRIPTION
There is an easy to use bind-chroot package on EL distributions, I have verified this working in my environment (Oracle Linux 8.4), but I don't know how to test this.
This might be a breaking change, since it requires systemd "named.service" to be stopped/disabled before starting "named-chroot.service", but it's fine for greenfield deployment.