### PR TITLE
Added support for OpenWrt 21.02.01

### DIFF
--- a/files/openwrt_named.rfc1912.zones
+++ b/files/openwrt_named.rfc1912.zones
@@ -1,0 +1,28 @@
+// prime the server with knowledge of the root servers
+zone "." {
+        type hint;
+        file "/etc/bind/db.root";
+};
+
+// be authoritative for the localhost forward and reverse zones, and for
+// broadcast zones as per RFC 1912
+
+zone "localhost" {
+        type master;
+        file "/etc/bind/db.local";
+};
+
+zone "127.in-addr.arpa" {
+        type master;
+        file "/etc/bind/db.127";
+};
+
+zone "0.in-addr.arpa" {
+        type master;
+        file "/etc/bind/db.0";
+};
+
+zone "255.in-addr.arpa" {
+        type master;
+        file "/etc/bind/db.255";
+};

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -30,6 +30,8 @@ galaxy_info:
         - xenial
         - bionic
         - focal
+    - name: OpenWrt
+        - 21.02.01
   galaxy_tags:
     - dns
     - networking

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,6 +71,32 @@
   become: yes
   tags: bind
 
+- name: Prepare bind on OpenWrt
+  block:
+    - name: "Create RFC1912 zones file"
+      copy:
+        src: "openwrt_named.rfc1912.zones" 
+        dest: "{{ bind_conf_dir }}/named.rfc1912.zones"
+        owner: "{{ bind_owner }}"
+        group: "{{ bind_group }}"
+        mode: 0770
+        setype: named_cache_t
+    
+    - name: "Create default named.conf"
+      copy:
+        dest: "{{ bind_conf_dir }}/named.conf"
+        owner: "{{ bind_owner }}"
+        group: "{{ bind_group }}"
+        mode: 0770
+        setype: named_cache_t
+        content: |
+          include "{{ bind_config }}";
+          include "/etc/bind/named-rndc.conf";
+          include "/etc/bind/named.rfc1912.zones";
+
+  when: ansible_os_family == 'OpenWrt'
+  tags: bind
+
 - name: Create serial, based on UTC UNIX time
   command: date -u +%s
   register: timestamp

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -91,7 +91,6 @@
         setype: named_cache_t
         content: |
           include "{{ bind_config }}";
-          include "/etc/bind/named-rndc.conf";
           include "/etc/bind/named.rfc1912.zones";
 
   when: ansible_os_family == 'OpenWrt'

--- a/templates/etc_named.conf.j2
+++ b/templates/etc_named.conf.j2
@@ -38,7 +38,9 @@ options {
 
   rrset-order { order {{ bind_rrset_order }}; };
 
+{% if ansible_distribution != 'OpenWrt' %} 
 {% if bind_dnssec_enable %}  dnssec-enable {{ bind_dnssec_enable }};{% endif %}
+{% endif %}
   dnssec-validation {{ bind_dnssec_validation }};
 
   /* Path to ISC DLV key */

--- a/vars/OpenWrt.yml
+++ b/vars/OpenWrt.yml
@@ -1,0 +1,41 @@
+# Distro specific variables for OpenWrt
+---
+bind_default_python_version: '3'
+bind_packages:
+#  - "{{ ( bind_python_version == '3' ) | ternary( 'python3-netaddr', 'python-netaddr' ) }}"
+  - "{{ ( bind_python_version == '3' ) | ternary( 'python3-dns', 'python-dns' ) }}"
+  - bind-check
+  - bind-client
+  - bind-dig
+  - bind-dnssec
+  - bind-host
+  - bind-libs
+  - bind-nslookup
+  - bind-rndc
+  - bind-server
+  - bind-tools
+
+bind_service: named
+
+# Main config file
+bind_config: /etc/bind/named.conf.local
+
+# Zone files included in the installation
+bind_default_zone_files: []
+
+# Directory with run-time stuff
+bind_dir: /var/bind
+bind_conf_dir: "/etc/bind"
+auth_file: "auth_transfer.conf"
+bind_auth_file: "{{ bind_conf_dir }}/{{ auth_file }}"
+
+bind_owner: root
+bind_group: bind
+
+bind_bindkeys_file: "/etc/bind/bind.keys"
+bind_pid_file: "/var/run/named/named.pid"
+bind_session_keyfile: "/var/run/named/session.key"
+
+# Custom location for zone files
+bind_zone_dir: "{{ bind_dir }}"
+bind_secondary_dir: "{{ bind_dir }}/secondary"

--- a/vars/OpenWrt.yml
+++ b/vars/OpenWrt.yml
@@ -2,15 +2,12 @@
 ---
 bind_default_python_version: '3'
 bind_packages:
-#  - "{{ ( bind_python_version == '3' ) | ternary( 'python3-netaddr', 'python-netaddr' ) }}"
   - "{{ ( bind_python_version == '3' ) | ternary( 'python3-dns', 'python-dns' ) }}"
   - bind-check
   - bind-client
   - bind-dig
   - bind-dnssec
-  - bind-host
   - bind-libs
-  - bind-nslookup
   - bind-rndc
   - bind-server
   - bind-tools

--- a/vars/OpenWrt.yml
+++ b/vars/OpenWrt.yml
@@ -21,7 +21,7 @@ bind_config: /etc/bind/named.conf.local
 bind_default_zone_files: []
 
 # Directory with run-time stuff
-bind_dir: /var/bind
+bind_dir: /etc/bind
 bind_conf_dir: "/etc/bind"
 auth_file: "auth_transfer.conf"
 bind_auth_file: "{{ bind_conf_dir }}/{{ auth_file }}"
@@ -34,5 +34,5 @@ bind_pid_file: "/var/run/named/named.pid"
 bind_session_keyfile: "/var/run/named/session.key"
 
 # Custom location for zone files
-bind_zone_dir: "{{ bind_dir }}"
-bind_secondary_dir: "{{ bind_dir }}/secondary"
+bind_zone_dir: "{{ bind_dir }}/zones"
+bind_secondary_dir: "{{ bind_dir }}/zones/secondary"


### PR DESCRIPTION
With this PR I added support for OpenWrt version 21.02.01.
Please note that OpenWrt is different to "default" Linux distributions, as everything is trimmed as much as possible as usually space is very valuable, thus there is a number of things, which are different (for instance the necessary packages are split across multiple smaller packages).

I don't know if it is of use for anybody else, but I thought, I'd contribute as the role works perfectly fine. I tried to adhere to the existing coding style.

Let me know if anything needs to be changed in order to get this PR done.

All the best,
Steffen