### PR TITLE
Permit a different TTL per DNS Zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The packages `python-netaddr` (required for the [`ipaddr`](https://docs.ansible.
 | `- text`                    | `[]`                 | A list of mappings with keys `name:` and `text:`, specifying TXT records. `text:` can be a list or string.                           |
 | `- caa`                     | `[]`                 | A list of mappings with keys `name:` and `text:`, specifying CAA records. `text:` can be a list or string.                           |
 | `- type`                    | -                    | Optional zone type. If not specified, autodetection will be used. Possible values include `primary`, `secondary` or `forward`        |
+| `- ttl`                     | `bind_zone_ttl`      | Optional ttl for this zone. If not specified, use default value `bind_zone_ttl`                                                      |
 | `bind_zone_file_mode`       | 0640                 | The file permissions for the main config file (named.conf)                                                                           |
 | `bind_zone_minimum_ttl`     | `1D`                 | Minimum TTL field in the SOA record.                                                                                                 |
 | `bind_zone_time_to_expire`  | `1W`                 | Time to expire field in the SOA record.                                                                                              |

--- a/templates/bind_zone.j2
+++ b/templates/bind_zone.j2
@@ -4,7 +4,7 @@
  #  way the serial will only be updated if there are some content changes.
  #}
 {% set _zone_data = {} %}
-{% set _ = _zone_data.update({'ttl': bind_zone_ttl}) %}
+{% set _ = _zone_data.update({'ttl': item.ttl|default(bind_zone_ttl)}) %}
 {% set _ = _zone_data.update({'domain': item.name}) %}
 {% set _ = _zone_data.update({'mname': item.name_servers|default([])}) %}
 {% set _ = _zone_data.update({'aname': item.other_name_servers|default([])}) %}


### PR DESCRIPTION
Permit to override the ttl for specific zone.
Default value is used if the zone don't have specific ttl information
