### PR TITLE
Added response-policy zone functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The packages `python-netaddr` (required for the [`ipaddr`](https://docs.ansible.
 | `- networks`                | `['10.0.2']`         | A list of the networks that are part of the domain                                                                                   |
 | `- other_name_servers`      | `[]`                 | A list of the DNS servers outside of this domain.                                                                                    |
 | `- primaries`               | -                    | A list of primary DNS servers for this zone.                                                                                         |
+| `- response_policy          | `false`              | Whether the zone is a response policy zone (https://www.isc.org/rpz/).                                                               |
 | `- services`                | `[]`                 | A list of services to be advertised by SRV records                                                                                   |
 | `- text`                    | `[]`                 | A list of mappings with keys `name:` and `text:`, specifying TXT records. `text:` can be a list or string.                           |
 | `- caa`                     | `[]`                 | A list of mappings with keys `name:` and `text:`, specifying CAA records. `text:` can be a list or string.                           |

--- a/molecule/default/host_vars/ns1.yml
+++ b/molecule/default/host_vars/ns1.yml
@@ -94,3 +94,16 @@ bind_zones:
         text:
           - 'some text'
           - 'more text'
+  - name: 'rpz'
+    create_reverse_zones: false
+    response_policy: true
+    primaries:
+      - 10.11.0.1
+    name_servers:
+      - ns1.acme-inc.com.
+      - ns2.acme-inc.com.
+    hostmaster_email: admin
+    hosts:
+      - name: blackhole.example2.com
+        ip: 1.2.3.5
+        ipv6: '2001:db10::100'

--- a/molecule/default/host_vars/ns2.yml
+++ b/molecule/default/host_vars/ns2.yml
@@ -19,3 +19,8 @@ bind_zones:
       - '10.11'
     ipv6_networks:
       - '2001:db8::/48'
+  - name: 'rpz'
+    create_reverse_zones: false
+    response_policy: true
+    primaries:
+      - 10.11.0.1

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -18,19 +18,25 @@
     - name: IPv4 Forward lookups
       assert:
         that:
-          - lookup('dig', 'ns1.acme-inc.com', local_dns )    == '10.11.0.1'
-          - lookup('dig', 'ns2.acme-inc.com', local_dns)     == '10.11.0.2'
-          - lookup('dig', 'srv001.acme-inc.com', local_dns)  == '10.11.1.1'
-          - lookup('dig', 'srv002.acme-inc.com', local_dns)  == '10.11.1.2'
-          - lookup('dig', 'mail001.acme-inc.com', local_dns) == '10.11.2.1'
-          - lookup('dig', 'mail002.acme-inc.com', local_dns) == '10.11.2.2'
-          - lookup('dig', 'mail003.acme-inc.com', local_dns) == '10.11.2.3'
-          - lookup('dig', 'srv010.acme-inc.com', local_dns)  == '10.11.0.10'
-          - lookup('dig', 'srv011.acme-inc.com', local_dns)  == '10.11.0.11'
-          - lookup('dig', 'srv012.acme-inc.com', local_dns)  == '10.11.0.12'
-          - lookup('dig', 'srv001.example.com', local_dns)   == '192.0.2.1'
-          - lookup('dig', 'srv002.example.com', local_dns)   == '192.0.2.2'
-          - lookup('dig', 'mail001.example.com', local_dns)  == '192.0.2.10'
+          - lookup('dig', 'ns1.acme-inc.com', local_dns )      == '10.11.0.1'
+          - lookup('dig', 'ns2.acme-inc.com', local_dns)       == '10.11.0.2'
+          - lookup('dig', 'srv001.acme-inc.com', local_dns)    == '10.11.1.1'
+          - lookup('dig', 'srv002.acme-inc.com', local_dns)    == '10.11.1.2'
+          - lookup('dig', 'mail001.acme-inc.com', local_dns)   == '10.11.2.1'
+          - lookup('dig', 'mail002.acme-inc.com', local_dns)   == '10.11.2.2'
+          - lookup('dig', 'mail003.acme-inc.com', local_dns)   == '10.11.2.3'
+          - lookup('dig', 'srv010.acme-inc.com', local_dns)    == '10.11.0.10'
+          - lookup('dig', 'srv011.acme-inc.com', local_dns)    == '10.11.0.11'
+          - lookup('dig', 'srv012.acme-inc.com', local_dns)    == '10.11.0.12'
+          - lookup('dig', 'srv001.example.com', local_dns)     == '192.0.2.1'
+          - lookup('dig', 'srv002.example.com', local_dns)     == '192.0.2.2'
+          - lookup('dig', 'mail001.example.com', local_dns)    == '192.0.2.10'
+
+    - name: IPv4 Forward lookups (response policy zone)
+      assert:
+        that:
+          - lookup('dig', 'blackhole.example2.com', local_dns) == '1.2.3.5'
+      when: inventory_hostname != 'ns3'
 
     - name: IPv4 Reverse lookups
       assert:
@@ -63,12 +69,18 @@
     - name: IPv6 Forward lookups
       assert:
         that:
-          - lookup('dig', 'srv001.acme-inc.com/AAAA', local_dns)  == '2001:db8::1'
-          - lookup('dig', 'srv002.acme-inc.com/AAAA', local_dns)  == '2001:db8::2'
-          - lookup('dig', 'mail001.acme-inc.com/AAAA', local_dns) == '2001:db8::d:1'
-          - lookup('dig', 'mail002.acme-inc.com/AAAA', local_dns) == '2001:db8::d:2'
-          - lookup('dig', 'mail003.acme-inc.com/AAAA', local_dns) == '2001:db8::d:3'
-          - lookup('dig', 'srv001.example.com/AAAA', local_dns)   == '2001:db9::1'
+          - lookup('dig', 'srv001.acme-inc.com/AAAA', local_dns)    == '2001:db8::1'
+          - lookup('dig', 'srv002.acme-inc.com/AAAA', local_dns)    == '2001:db8::2'
+          - lookup('dig', 'mail001.acme-inc.com/AAAA', local_dns)   == '2001:db8::d:1'
+          - lookup('dig', 'mail002.acme-inc.com/AAAA', local_dns)   == '2001:db8::d:2'
+          - lookup('dig', 'mail003.acme-inc.com/AAAA', local_dns)   == '2001:db8::d:3'
+          - lookup('dig', 'srv001.example.com/AAAA', local_dns)     == '2001:db9::1'
+
+    - name: IPv6 Forward lookups (response policy zone)
+      assert:
+        that:
+          - lookup('dig', 'blackhole.example2.com/AAAA', local_dns) == '2001:db10::100'
+      when: inventory_hostname != 'ns3'
 
     - name: IPv6 Reverse lookups
       assert:

--- a/molecule/shared_inventory/group_vars/all.yml
+++ b/molecule/shared_inventory/group_vars/all.yml
@@ -117,3 +117,16 @@ bind_zones:
         text:
           - 'some text'
           - 'more text'
+  - name: 'rpz'
+    create_reverse_zones: false
+    response_policy: true
+    primaries:
+      - 10.11.0.4
+    name_servers:
+      - ns1.acme-inc.com.
+      - ns2.acme-inc.com.
+    hostmaster_email: admin
+    hosts:
+      - name: blackhole.example2.com
+        ip: 1.2.3.5
+        ipv6: '2001:db10::100'

--- a/molecule/shared_inventory/verify.yml
+++ b/molecule/shared_inventory/verify.yml
@@ -18,19 +18,20 @@
     - name: IPv4 Forward lookups
       assert:
         that:
-          - lookup('dig', 'ns1.acme-inc.com', local_dns )    == '10.11.0.4'
-          - lookup('dig', 'ns2.acme-inc.com', local_dns)     == '10.11.0.5'
-          - lookup('dig', 'srv001.acme-inc.com', local_dns)  == '10.11.1.1'
-          - lookup('dig', 'srv002.acme-inc.com', local_dns)  == '10.11.1.2'
-          - lookup('dig', 'mail001.acme-inc.com', local_dns) == '10.11.2.1'
-          - lookup('dig', 'mail002.acme-inc.com', local_dns) == '10.11.2.2'
-          - lookup('dig', 'mail003.acme-inc.com', local_dns) == '10.11.2.3'
-          - lookup('dig', 'srv010.acme-inc.com', local_dns)  == '10.11.0.10'
-          - lookup('dig', 'srv011.acme-inc.com', local_dns)  == '10.11.0.11'
-          - lookup('dig', 'srv012.acme-inc.com', local_dns)  == '10.11.0.12'
-          - lookup('dig', 'srv001.example.com', local_dns)   == '192.0.2.1'
-          - lookup('dig', 'srv002.example.com', local_dns)   == '192.0.2.2'
-          - lookup('dig', 'mail001.example.com', local_dns)  == '192.0.2.10'
+          - lookup('dig', 'ns1.acme-inc.com', local_dns )      == '10.11.0.4'
+          - lookup('dig', 'ns2.acme-inc.com', local_dns)       == '10.11.0.5'
+          - lookup('dig', 'srv001.acme-inc.com', local_dns)    == '10.11.1.1'
+          - lookup('dig', 'srv002.acme-inc.com', local_dns)    == '10.11.1.2'
+          - lookup('dig', 'mail001.acme-inc.com', local_dns)   == '10.11.2.1'
+          - lookup('dig', 'mail002.acme-inc.com', local_dns)   == '10.11.2.2'
+          - lookup('dig', 'mail003.acme-inc.com', local_dns)   == '10.11.2.3'
+          - lookup('dig', 'srv010.acme-inc.com', local_dns)    == '10.11.0.10'
+          - lookup('dig', 'srv011.acme-inc.com', local_dns)    == '10.11.0.11'
+          - lookup('dig', 'srv012.acme-inc.com', local_dns)    == '10.11.0.12'
+          - lookup('dig', 'srv001.example.com', local_dns)     == '192.0.2.1'
+          - lookup('dig', 'srv002.example.com', local_dns)     == '192.0.2.2'
+          - lookup('dig', 'mail001.example.com', local_dns)    == '192.0.2.10'
+          - lookup('dig', 'blackhole.example2.com', local_dns) == '1.2.3.5'
 
     - name: IPv4 Reverse lookups
       assert:
@@ -63,12 +64,13 @@
     - name: IPv6 Forward lookups
       assert:
         that:
-          - lookup('dig', 'srv001.acme-inc.com/AAAA', local_dns)  == '2001:db8::1'
-          - lookup('dig', 'srv002.acme-inc.com/AAAA', local_dns)  == '2001:db8::2'
-          - lookup('dig', 'mail001.acme-inc.com/AAAA', local_dns) == '2001:db8::d:1'
-          - lookup('dig', 'mail002.acme-inc.com/AAAA', local_dns) == '2001:db8::d:2'
-          - lookup('dig', 'mail003.acme-inc.com/AAAA', local_dns) == '2001:db8::d:3'
-          - lookup('dig', 'srv001.example.com/AAAA', local_dns)   == '2001:db9::1'
+          - lookup('dig', 'srv001.acme-inc.com/AAAA', local_dns)    == '2001:db8::1'
+          - lookup('dig', 'srv002.acme-inc.com/AAAA', local_dns)    == '2001:db8::2'
+          - lookup('dig', 'mail001.acme-inc.com/AAAA', local_dns)   == '2001:db8::d:1'
+          - lookup('dig', 'mail002.acme-inc.com/AAAA', local_dns)   == '2001:db8::d:2'
+          - lookup('dig', 'mail003.acme-inc.com/AAAA', local_dns)   == '2001:db8::d:3'
+          - lookup('dig', 'srv001.example.com/AAAA', local_dns)     == '2001:db9::1'
+          - lookup('dig', 'blackhole.example2.com/AAAA', local_dns) == '2001:db10::100'
 
     - name: IPv6 Reverse lookups
       assert:

--- a/templates/bind_zone.j2
+++ b/templates/bind_zone.j2
@@ -24,6 +24,7 @@
 {% set _ = _zone_data.update({'text': item.text|default([])}) %}
 {% set _ = _zone_data.update({'caa': item.caa|default([])}) %}
 {% set _ = _zone_data.update({'naptr': item.naptr|default([])}) %}
+{% set _rpz = true if (item.response_policy is defined and item.response_policy is sameas true) else false %}
 {#
  #  Compare the zone file hash with the current zone data hash and set serial
  #  accordingly
@@ -44,7 +45,9 @@
 ; Zone file for {{ _zone_data['domain'] }}
 {{ ansible_managed | comment(decoration='; ') }}
 
+{% if _rpz is sameas false %}
 $ORIGIN {{ _zone_data['domain'] }}.
+{% endif %}
 $TTL {{ _zone_data['ttl'] }}
 
 {% if _zone_data['mname']|length > 0 %}

--- a/templates/etc_named.conf.j2
+++ b/templates/etc_named.conf.j2
@@ -36,6 +36,14 @@ options {
 {% if bind_forwarders|length > 0 %}forwarders { {{ bind_forwarders|join('; ') }}; };{% endif %}
   {% if bind_forward_only %}forward only;{% endif %}
 
+{% if bind_zones | selectattr('response_policy', 'defined') | selectattr('response_policy', 'equalto', true) | list | length > 0 %}
+  response-policy {
+{% for zone in bind_zones | selectattr('response_policy', 'defined') | selectattr('response_policy', 'equalto', true) | list %}
+    zone "{{ zone.name }}";
+{% endfor %}
+  };
+{% endif %}
+
   rrset-order { order {{ bind_rrset_order }}; };
 
 {% if bind_dnssec_enable %}  dnssec-enable {{ bind_dnssec_enable }};{% endif %}


### PR DESCRIPTION
I've made some changes to allow for configuring response policy zones with this role.

The one thing I'm not so sure about are the molecule tests for the default scenario.  Since ns3 is only a forwarder, I've excluded the response policy zone tests in the verify.yml since we can't easily conditionally forward to ns1/2 - due to response policy zone allowing override of any domain/fqdn records.