### PR TITLE
Add Rocky-8 support

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -2,8 +2,8 @@
 ---
 bind_default_python_version: "{{ ( ansible_distribution_major_version == '8' ) | ternary( '3', '2' ) }}"
 bind_packages:
-  - "{{ ( bind_python_version == '3' ) | ternary( 'python3-netaddr', 'python-netaddr' ) }}"
-  - "{{ ( bind_python_version == '3' ) | ternary( 'python3-dns', 'python-dns' ) }}"
+  - "{{ ( ( bind_python_version | int ) == 3 ) | ternary( 'python3-netaddr', 'python-netaddr' ) }}"
+  - "{{ ( ( bind_python_version | int ) == 3 ) | ternary( 'python3-dns', 'python-dns' ) }}"
   - bind
   - bind-utils
 


### PR DESCRIPTION
On Rocky 8.5 `bind_python_version` is not a character/string but a integer. The role try to instal python-netaddr instead of python3-netaddr.

Debug here:
```yaml
TASK [bertvv.bind : Debug ansible_distribution ] *******************************************************************************************************************************************************************************************************************************************************
ok: [my_rocky_system] => {
    "ansible_distribution": "Rocky"
}

TASK [bertvv.bind : Debug ansible_distribution_major_version] *******************************************************************************************************************************************************************************************************************************************************
ok: [my_rocky_system] => {
    "ansible_distribution_major_version": 8
}

TASK [bertvv.bind : Debug bind_python_version] *******************************************************************************************************************************************************************************************************************************************************
ok: [my_rocky_system] => {
    "bind_python_version": 3
}

TASK [bertvv.bind : Debug bind_default_python_version] *******************************************************************************************************************************************************************************************************************************************************
ok: [my_rocky_system] => {
    "bind_default_python_version": 3
}

TASK [bertvv.bind : Debug bind_packages] *******************************************************************************************************************************************************************************************************************************************************
ok: [my_rocky_system] => {
    "bind_packages": [
        "python-netaddr",
        "python-dns",
        "bind",
        "bind-utils"
    ]
}

TASK [bertvv.bind : Install BIND] ************************************************************************************************************************************************************************************************************************************************
failed: [my_rocky_system] (item=python-netaddr) => {"ansible_loop_var": "item", "changed": false, "failures": ["No package python-netaddr available."], "item": "python-netaddr", "msg": "Failed to install some of the specified packages", "rc": 1, "results": []}
failed: [my_rocky_system] (item=python-dns) => {"ansible_loop_var": "item", "changed": false, "failures": ["No package python-dns available."], "item": "python-dns", "msg": "Failed to install some of the specified packages", "rc": 1, "results": []}
ok: [my_rocky_system] => (item=bind) => {"ansible_loop_var": "item", "changed": false, "item": "bind", "msg": "Nothing to do", "rc": 0, "results": []}
ok: [my_rocky_system] => (item=bind-utils) => {"ansible_loop_var": "item", "changed": false, "item": "bind-utils", "msg": "Nothing to do", "rc": 0, "results": []}

PLAY RECAP ***********************************************************************************************************************************************************************************************************************************************************************
my_rocky_system : ok=26   changed=0    unreachable=0    failed=1    skipped=4    rescued=0    ignored=0   

```
