### PR TITLE
update the FreeBSD versions of the bind_packages for FreeBSD 12 and upwards

### DIFF
--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -2,9 +2,9 @@
 ---
 
 bind_packages:
-  - py37-netaddr
-  - py37-dnspython
-  - bind911
+  - py39-netaddr
+  - py39-dnspython
+  - bind918
 
 bind_service: named
 


### PR DESCRIPTION
The bind packages in the role used for FreeBSD aren't very up to date any more, the changes reflect the available packages for py-netaddr, py-dnspython and bind in particular. 
Nonetheless one has to check if he really is using Python 3.9 on the Bind Server Machine he wishes to configure.