### PR TITLE
add Debian11

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,6 +17,7 @@ galaxy_info:
         - jessie
         - stretch
         - buster
+        - bullseye
     - name: FreeBSD
       versions:
         - 12.1

--- a/vars/Debian-11.yml
+++ b/vars/Debian-11.yml
@@ -1,0 +1,34 @@
+# Distro specific variables for Debian
+---
+bind_default_python_version: '3'
+bind_packages:
+  - "{{ ( bind_python_version == '3' ) | ternary( 'python3-netaddr', 'python-netaddr' ) }}"
+  - "{{ ( bind_python_version == '3' ) | ternary( 'python3-dnspython', 'python-dnspython' ) }}"
+  - bind9
+  - bind9utils
+
+bind_service: named
+
+# Main config file
+bind_config: /etc/bind/named.conf
+
+# Localhost zone
+bind_default_zone_files:
+  - /etc/bind/named.conf.default-zones
+
+# Directory with run-time stuff
+bind_dir: /var/cache/bind
+bind_conf_dir: "/etc/bind"
+auth_file: "auth_transfer.conf"
+bind_auth_file: "{{ bind_conf_dir }}/{{ auth_file }}"
+
+bind_owner: root
+bind_group: bind
+
+bind_bindkeys_file: "/etc/named.iscdlv.key"
+bind_pid_file: "/run/named/named.pid"
+bind_session_keyfile: "/run/named/session.key"
+
+# Custom location for zone files
+bind_zone_dir: "{{ bind_dir }}"
+bind_secondary_dir: "{{ bind_dir }}/secondary"


### PR DESCRIPTION
Add Debian11 as supported by this Role

Just need a very small modification, the service name is now `named`, earlier Debian version was `bind9`

So created the `vars/Debian-11.yml` with `bind_service: named `
Instead of `bind_service: bind9` in `vars/Debian.yml`

Fix #202 