### PR TITLE
Fix python version test with jinja2_native

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,8 +2,8 @@
 ---
 bind_default_python_version: '3'
 bind_packages:
-  - "{{ ( bind_python_version == '3' ) | ternary( 'python3-netaddr', 'python-netaddr' ) }}"
-  - "{{ ( bind_python_version == '3' ) | ternary( 'python3-dnspython', 'python-dnspython' ) }}"
+  - "{{ ( bind_python_version | string == '3' ) | ternary( 'python3-netaddr', 'python-netaddr' ) }}"
+  - "{{ ( bind_python_version | string == '3' ) | ternary( 'python3-dnspython', 'python-dnspython' ) }}"
   - bind9
   - bind9utils
 

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -2,8 +2,8 @@
 ---
 bind_default_python_version: "{{ ( ansible_distribution_major_version == '8' ) | ternary( '3', '2' ) }}"
 bind_packages:
-  - "{{ ( bind_python_version == '3' ) | ternary( 'python3-netaddr', 'python-netaddr' ) }}"
-  - "{{ ( bind_python_version == '3' ) | ternary( 'python3-dns', 'python-dns' ) }}"
+  - "{{ ( bind_python_version | string == '3' ) | ternary( 'python3-netaddr', 'python-netaddr' ) }}"
+  - "{{ ( bind_python_version | string == '3' ) | ternary( 'python3-dns', 'python-dns' ) }}"
   - bind
   - bind-utils
 


### PR DESCRIPTION
If the ansible configuration setting "jinja2_native" is enabled, ansible (or jinja2?) tries to preserve the type of the variable, e.g. by casting a string like `'2'` to a number `2`.

This PR will a problem with this setting enabled with the variable `bind_packages` in `vars/Debian.yml` and `vars/RedHat.yml`, where package name gets selected, depending on the configured `bind_python_version` variable.

If `jinja_native=true` the value of `bind_python_version` would have been a number, selecting e.g. the non-existing python-netaddr package on some newer debian systems.
Preventively casting the value to a string prevents this without breaking previous behaviour.