### PR TITLE
Big update, reduce warning message in lint and merge from pending

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,17 +10,15 @@ jobs:
 
   test:
     name: Molecule
-    runs-on: ubuntu-latest
+    runs-on: ["self-hosted"]
     strategy:
       matrix:
         distro:
-          - centos7
           - centos8
-          - debian8
-          - debian9
+          - centos7
           - debian10
-          - ubuntu1604
-          - ubuntu1804
+          - debian9
+          - ubuntu2204
           - ubuntu2004
 
     steps:
@@ -35,8 +33,36 @@ jobs:
       - name: Install test dependencies.
         run: pip3 install ansible molecule molecule-docker yamllint ansible-lint docker netaddr dnspython
 
-      - name: Run Molecule Primary/Secondary/Forwarder tests
-        run: molecule test
+      - name: Install galaxy role
+        run: |
+          ansible-galaxy role install -f -r requirements.yml
+          ansible-galaxy role remove udienz.bind
+
+      - name: Run Molecule Primary/Secondary/Forwarder converge
+        run: molecule converge
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          MOLECULE_DISTRO: ${{ matrix.distro }}
+
+      - name: Copy artifact
+        run: |
+          mkdir ${{ github.workspace }}/${{ matrix.distro }}
+          docker cp ${{ matrix.distro }}:/etc/named.conf ${{ github.workspace }}/${{ matrix.distro }}/etc/named.conf
+          docker cp ${{ matrix.distro }}:/etc/named/ ${{ github.workspace }}/${{ matrix.distro }}/etc/named/
+          docker cp ${{ matrix.distro }}:/etc/var/named/ ${{ github.workspace }}/${{ matrix.distro }}/var/named/
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: Artifact for ${{ matrix.distro }}
+          path: |
+           ${{ github.workspace }}/${{ matrix.distro }}/var/named/
+           ${{ github.workspace }}/${{ matrix.distro }}/etc/named/
+           ${{ github.workspace }}/${{ matrix.distro }}/etc/named.conf
+
+      - name: Run Molecule Primary/Secondary/Forwarder destroy
+        run: molecule destroy
         env:
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'

--- a/.yamllint
+++ b/.yamllint
@@ -1,5 +1,4 @@
 ---
-
 rules:
   braces:
     min-spaces-inside: 0
@@ -53,5 +52,5 @@ rules:
     type: unix
   trailing-spaces: enable
   truthy:
-    allowed-values: ['true', 'false', 'yes', 'no']
+    allowed-values: ["true", "false", "yes", "no"]
     level: warning

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,11 +1,8 @@
 ---
-
 # List of zones for which this name server is authoritative
 bind_zones: []
-
 # List of acls.
 bind_acls: []
-
 # Key binding for secondary servers
 bind_dns_keys: []
 #  - name: primary_key
@@ -15,7 +12,7 @@ bind_dns_keys: []
 # List of IPv4 address of the network interface(s) to listen on. Set to "any"
 # to listen on all interfaces
 bind_listen_ipv4:
-  - "127.0.0.1"
+  - 127.0.0.1
 
 # The list of ports to listen on for IPv4 addresses
 bind_listen_ipv4_port:
@@ -23,7 +20,7 @@ bind_listen_ipv4_port:
 
 # List of IPv6 address of the network interface(s) to listen on.
 bind_listen_ipv6:
-  - "::1"
+  - ::1
 
 # The list of ports to listen on for IPv6 addresses
 bind_listen_ipv6_port:
@@ -31,45 +28,42 @@ bind_listen_ipv6_port:
 
 # List of hosts that are allowed to query this DNS server.
 bind_allow_query:
-  - "localhost"
+  - localhost
 
 # A key-value list mapping server-IPs to TSIG keys for signing requests
 bind_key_mapping: {}
-
 # Determines whether recursion should be allowed. Typically, an authoritative
 # name server should have recursion turned OFF.
 bind_recursion: false
 bind_allow_recursion:
-  - "any"
+  - any
 
 # Allows BIND to be set up as a caching name server
 bind_forward_only: false
 
 # List of name servers to forward DNS requests to.
 bind_forwarders: []
-
 # DNS round robin order (random or cyclic)
-bind_rrset_order: "random"
+bind_rrset_order: random
 
 # statistics channels configuration
 bind_statistics_channels: false
 bind_statistics_port: 8053
 bind_statistics_host: 127.0.0.1
 bind_statistics_allow:
-  - "127.0.0.1"
+  - 127.0.0.1
 
 # DNSSEC configuration
 bind_dnssec_enable: true
 bind_dnssec_validation: true
 
 bind_extra_include_files: []
-
 # SOA information
-bind_zone_ttl: "1W"
-bind_zone_time_to_refresh: "1D"
-bind_zone_time_to_retry: "1H"
-bind_zone_time_to_expire: "1W"
-bind_zone_minimum_ttl: "1D"
+bind_zone_ttl: 1W
+bind_zone_time_to_refresh: 1D
+bind_zone_time_to_retry: 1H
+bind_zone_time_to_expire: 1W
+bind_zone_minimum_ttl: 1D
 
 # File mode for primary zone files (needs to be something like 0660 for dynamic updates)
 bind_zone_file_mode: "0640"
@@ -77,10 +71,12 @@ bind_zone_file_mode: "0640"
 # DNS64 support
 bind_dns64: false
 bind_dns64_clients:
-  - "any"
+  - any
 
 # Set Python version
 bind_python_version: "{{ bind_default_python_version }}"
 
 # Log file
-bind_log: "data/named.run"
+#
+bind_log_dir: /var/log/{{ bind_service }}
+bind_log: "{{ bind_log_dir }}/{{ bind_service }}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,6 @@
 ---
-
-- name: reload bind
-  service:
+- name: Reload bind
+  ansible.builtin.service:
     name: "{{ bind_service }}"
     state: reloaded
-  become: yes
+  become: true

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -5,4 +5,4 @@
   hosts: all
 
   roles:
-    - role: "bertvv.bind"
+    - role: "udienz.bind"

--- a/molecule/default/group_vars/all.yml
+++ b/molecule/default/group_vars/all.yml
@@ -8,17 +8,30 @@ bind_allow_query:
   - any
 bind_listen_ipv4:
   - any
+bind_listen_ipv4_port:
+  - 53
+bind_listen_ipv6_port:
+  - 53
 bind_listen_ipv6:
   - any
 bind_acls:
   - name: acl1
     match_list:
       - 10.11.0.0/16
+bind_allow_recursion:
+  - any
+bind_forward_only: false
+bind_rrset_order: random
+bind_statistics_port: 8053
+bind_statistics_host: 127.0.0.1
+# DNS64 support
+bind_dns64: false
+bind_dns64_clients:
+  - any
 bind_forwarders:
   - '8.8.8.8'
   - '8.8.4.4'
 bind_recursion: true
-bind_dns64: true
 bind_query_log: 'data/query.log'
 bind_check_names: 'master ignore'
 bind_zone_minimum_ttl: "2D"
@@ -26,4 +39,10 @@ bind_zone_ttl: "2W"
 bind_zone_time_to_refresh: "2D"
 bind_zone_time_to_retry: "2H"
 bind_zone_time_to_expire: "2W"
-bind_statistics_host: "{{ ansible_default_ipv4.address }}"
+bind_key_mapping: {}
+bind_python_version: "{{ bind_default_python_version }}"
+bind_log_dir: "/var/log/{{ bind_service }}"
+bind_log: "{{ bind_log_dir }}/{{ bind_service }}"
+bind_dnssec_enable: true
+bind_dnssec_validation: true
+bind_extra_include_files: {}

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -26,13 +26,13 @@ platforms:
     networks:
       - name: bind
         ipv4_address: "10.11.0.1"
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2204}-ansible:latest"
     # Command to execute when the container starts
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     # Volumes to mount within the container. Important to enable systemd
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-      - ${PWD}:/etc/ansible/roles/bertvv.bind:ro
+      - ${PWD}:/etc/ansible/roles/udienz.bind:ro
       - ${PWD}/library:/root/.ansible/plugins/modules:ro
     # Give extended privileges to the container. Necessary for Systemd to
     # operate within the container. DO NOT use extended privileges in a
@@ -53,7 +53,7 @@ platforms:
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-      - ${PWD}:/etc/ansible/roles/bertvv.bind:ro
+      - ${PWD}:/etc/ansible/roles/udienz.bind:ro
       - ${PWD}/library:/root/.ansible/plugins/modules:ro
     privileged: true
     pre_build_image: true
@@ -66,11 +66,11 @@ platforms:
     networks:
       - name: bind
         ipv4_address: "10.11.0.3"
-    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos8}-ansible:latest"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian10}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-      - ${PWD}:/etc/ansible/roles/bertvv.bind:ro
+      - ${PWD}:/etc/ansible/roles/udienz.bind:ro
       - ${PWD}/library:/root/.ansible/plugins/modules:ro
     privileged: true
     pre_build_image: true
@@ -81,12 +81,16 @@ platforms:
 
 provisioner:
   name: ansible
+  playbooks:
+    converge: ../../playbook.yml
+  inventory:
+    links:
+      group_vars: group_vars/
+      host_vars: host_vars/
   config_options:
     defaults:
       interpreter_python: auto_legacy_silent
       callback_whitelist: profile_tasks
-    ssh_connection:
-      pipelining: true
 
 # Runs the verify.yml playbook
 verifier:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -7,16 +7,16 @@
 
     # Only collect network facts to reduce setup time
     - name: Gathering Facts
-      setup:
+      ansible.builtin.setup:
         gather_subset:
           - 'network'
 
     - name: Set local_dns variable for dig
-      set_fact:
+      ansible.builtin.set_fact:
         local_dns: "{{ '@' + ansible_default_ipv4.address }}"
 
     - name: IPv4 Forward lookups
-      assert:
+      ansible.builtin.assert:
         that:
           - lookup('dig', 'ns1.acme-inc.com', local_dns )    == '10.11.0.1'
           - lookup('dig', 'ns2.acme-inc.com', local_dns)     == '10.11.0.2'
@@ -33,7 +33,7 @@
           - lookup('dig', 'mail001.example.com', local_dns)  == '192.0.2.10'
 
     - name: IPv4 Reverse lookups
-      assert:
+      ansible.builtin.assert:
         that:
           - lookup('dig', '10.11.0.1/PTR', local_dns)  == 'ns1.acme-inc.com.'
           - lookup('dig', '10.11.0.2/PTR', local_dns)  == 'ns2.acme-inc.com.'
@@ -50,7 +50,7 @@
           - lookup('dig', '192.0.2.10/PTR', local_dns) == 'mail001.example.com.'
 
     - name: IPv4 Alias lookups
-      assert:
+      ansible.builtin.assert:
         that:
           - lookup('dig', 'www.acme-inc.com', local_dns)      == '10.11.1.1'
           - lookup('dig', 'mysql.acme-inc.com', local_dns)    == '10.11.1.2'
@@ -61,7 +61,7 @@
           - lookup('dig', 'www.example.com', local_dns)       == '192.0.2.1'
 
     - name: IPv6 Forward lookups
-      assert:
+      ansible.builtin.assert:
         that:
           - lookup('dig', 'srv001.acme-inc.com/AAAA', local_dns)  == '2001:db8::1'
           - lookup('dig', 'srv002.acme-inc.com/AAAA', local_dns)  == '2001:db8::2'
@@ -71,7 +71,7 @@
           - lookup('dig', 'srv001.example.com/AAAA', local_dns)   == '2001:db9::1'
 
     - name: IPv6 Reverse lookups
-      assert:
+      ansible.builtin.assert:
         that:
           - lookup('dig', '2001:db8::1/PTR', local_dns)   == 'srv001.acme-inc.com.'
           - lookup('dig', '2001:db8::2/PTR', local_dns)   == 'srv002.acme-inc.com.'
@@ -82,24 +82,24 @@
           - lookup('dig', '2001:db9::1/PTR', local_dns)   == 'srv001.example.com.'
 
     - name: NS records lookup
-      assert:
+      ansible.builtin.assert:
         that:
           - lookup('dig', 'acme-inc.com/NS', local_dns).split(',') | sort | join(',') == 'ns1.acme-inc.com.,ns2.acme-inc.com.'
           - lookup('dig', 'example.com/NS', local_dns).split(',')  | sort | join(',') == 'ns1.acme-inc.com.,ns2.acme-inc.com.'
 
     - name: MX records lookup
-      assert:
+      ansible.builtin.assert:
         that:
           - lookup('dig', 'acme-inc.com/MX', local_dns).split(',') | sort | join(',') == '10 mail001.acme-inc.com.,20 mail002.acme-inc.com.'
           - lookup('dig', 'example.com/MX', local_dns).split(',')  | sort | join(',') == '10 mail001.example.com.'
 
     - name: Service records lookup
-      assert:
+      ansible.builtin.assert:
         that:
           - lookup('dig', '_ldap._tcp.acme-inc.com/SRV', local_dns) == '0 100 88 srv010.acme-inc.com.'
 
     - name: TXT records lookup
-      assert:
+      ansible.builtin.assert:
         that:
           - lookup('dig', '_kerberos.acme-inc.com/TXT', local_dns) == 'KERBEROS.ACME-INC.COM'
           - lookup('dig', 'acme-inc.com/TXT', local_dns).split(',') | sort | join(',') == 'more text,some text'

--- a/molecule/shared_inventory/molecule.yml
+++ b/molecule/shared_inventory/molecule.yml
@@ -29,7 +29,7 @@ platforms:
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-      - ${PWD}:/etc/ansible/roles/bertvv.bind:ro
+      - ${PWD}:/etc/ansible/roles/udienz.bind:ro
       - ${PWD}/library:/root/.ansible/plugins/modules:ro
     privileged: true
     pre_build_image: true
@@ -48,7 +48,7 @@ platforms:
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-      - ${PWD}:/etc/ansible/roles/bertvv.bind:ro
+      - ${PWD}:/etc/ansible/roles/udienz.bind:ro
       - ${PWD}/library:/root/.ansible/plugins/modules:ro
     privileged: true
     pre_build_image: true

--- a/molecule/shared_inventory/verify.yml
+++ b/molecule/shared_inventory/verify.yml
@@ -7,16 +7,16 @@
 
     # Only collect network facts to reduce setup time
     - name: Gathering Facts
-      setup:
+      ansible.builtin.setup:
         gather_subset:
           - 'network'
 
     - name: Set local_dns variable for dig
-      set_fact:
+      ansible.builtin.set_fact:
         local_dns: "{{ '@' + ansible_default_ipv4.address }}"
 
     - name: IPv4 Forward lookups
-      assert:
+      ansible.builtin.assert:
         that:
           - lookup('dig', 'ns1.acme-inc.com', local_dns )    == '10.11.0.4'
           - lookup('dig', 'ns2.acme-inc.com', local_dns)     == '10.11.0.5'
@@ -33,7 +33,7 @@
           - lookup('dig', 'mail001.example.com', local_dns)  == '192.0.2.10'
 
     - name: IPv4 Reverse lookups
-      assert:
+      ansible.builtin.assert:
         that:
           - lookup('dig', '10.11.0.4/PTR', local_dns)  == 'ns1.acme-inc.com.'
           - lookup('dig', '10.11.0.5/PTR', local_dns)  == 'ns2.acme-inc.com.'
@@ -50,7 +50,7 @@
           - lookup('dig', '192.0.2.10/PTR', local_dns) == 'mail001.example.com.'
 
     - name: IPv4 Alias lookups
-      assert:
+      ansible.builtin.assert:
         that:
           - lookup('dig', 'www.acme-inc.com', local_dns)      == '10.11.1.1'
           - lookup('dig', 'mysql.acme-inc.com', local_dns)    == '10.11.1.2'
@@ -61,7 +61,7 @@
           - lookup('dig', 'www.example.com', local_dns)       == '192.0.2.1'
 
     - name: IPv6 Forward lookups
-      assert:
+      ansible.builtin.assert:
         that:
           - lookup('dig', 'srv001.acme-inc.com/AAAA', local_dns)  == '2001:db8::1'
           - lookup('dig', 'srv002.acme-inc.com/AAAA', local_dns)  == '2001:db8::2'
@@ -71,7 +71,7 @@
           - lookup('dig', 'srv001.example.com/AAAA', local_dns)   == '2001:db9::1'
 
     - name: IPv6 Reverse lookups
-      assert:
+      ansible.builtin.assert:
         that:
           - lookup('dig', '2001:db8::1/PTR', local_dns)   == 'srv001.acme-inc.com.'
           - lookup('dig', '2001:db8::2/PTR', local_dns)   == 'srv002.acme-inc.com.'
@@ -82,24 +82,24 @@
           - lookup('dig', '2001:db9::1/PTR', local_dns)   == 'srv001.example.com.'
 
     - name: NS records lookup
-      assert:
+      ansible.builtin.assert:
         that:
           - lookup('dig', 'acme-inc.com/NS', local_dns).split(',') | sort | join(',') == 'ns1.acme-inc.com.,ns2.acme-inc.com.'
           - lookup('dig', 'example.com/NS', local_dns).split(',')  | sort | join(',') == 'ns1.acme-inc.com.,ns2.acme-inc.com.'
 
     - name: MX records lookup
-      assert:
+      ansible.builtin.assert:
         that:
           - lookup('dig', 'acme-inc.com/MX', local_dns).split(',') | sort | join(',') == '10 mail001.acme-inc.com.,20 mail002.acme-inc.com.'
           - lookup('dig', 'example.com/MX', local_dns).split(',')  | sort | join(',') == '10 mail001.example.com.'
 
     - name: Service records lookup
-      assert:
+      ansible.builtin.assert:
         that:
           - lookup('dig', '_ldap._tcp.acme-inc.com/SRV', local_dns) == '0 100 88 srv010.acme-inc.com.'
 
     - name: TXT records lookup
-      assert:
+      ansible.builtin.assert:
         that:
           - lookup('dig', '_kerberos.acme-inc.com/TXT', local_dns) == 'KERBEROS.ACME-INC.COM'
           - lookup('dig', 'acme-inc.com/TXT', local_dns).split(',') | sort | join(',') == 'more text,some text'

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,4 @@
+---
+- src: https://github.com/cak-cuk/ansible-role-bind
+  name: udienz.bind
+  version: development

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,7 @@
 ---
-
 # Initialise distribution-specific variables
 - name: Source specific variables
-  include_vars: "{{ item }}"
+  ansible.builtin.include_vars: "{{ item }}"
   with_first_found:
     - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
     - "{{ ansible_distribution }}.yml"
@@ -13,10 +12,10 @@
   tags: bind
 
 - name: Check `primaries` or `forwarders` was set for each zone
-  assert:
+  ansible.builtin.assert:
     that:
       - item.primaries is defined or item.forwarders is defined
-    quiet: yes
+    quiet: true
   loop: "{{ bind_zones }}"
   loop_control:
     label: "{{ item.name }}"
@@ -24,55 +23,56 @@
 
 # Fix molecule and ci failures
 - name: Update package cache for Debian based distros
-  apt:
-    update_cache: yes
-  become: yes
+  ansible.builtin.apt:
+    update_cache: true
+  become: true
   changed_when: false
   when: ansible_os_family == 'Debian'
   tags: bind
 
 - name: Assert that all XFR keys exist in the key list
-  assert:
+  ansible.builtin.assert:
     that: bind_dns_keys | selectattr("name","equalto",bind_key_mapping[item]) | list | count > 0
   loop: "{{ bind_key_mapping.keys() | list }}"
   when: bind_key_mapping | list | count > 0
 
 - name: Install BIND
-  package:
+  ansible.builtin.package:
     pkg: "{{ item }}"
     state: present
-  become: yes
+  become: true
   with_items:
     - "{{ bind_packages }}"
   tags: bind
 
 - name: Ensure runtime directories referenced in config exist
-  file:
+  ansible.builtin.file:
     path: "{{ item }}"
     state: directory
     owner: "{{ bind_owner }}"
     group: "{{ bind_group }}"
     mode: 0770
-  become: yes
+  become: true
   with_items:
     - "{{ bind_dir }}/dynamic"
     - "{{ bind_dir }}/data"
     - "{{ bind_zone_dir }}"
+    - "{{ bind_log_dir }}"
   tags: bind
 
 - name: Ensure Directory for Cached Secondary Zones exists
-  file:
+  ansible.builtin.file:
     path: "{{ bind_secondary_dir }}"
     state: directory
     owner: "{{ bind_owner }}"
     group: "{{ bind_group }}"
     mode: 0770
     setype: named_cache_t
-  become: yes
+  become: true
   tags: bind
 
 - name: Create serial, based on UTC UNIX time
-  command: date -u +%s
+  ansible.builtin.command: date -u +%s
   register: timestamp
   changed_when: false
   run_once: true
@@ -81,38 +81,38 @@
 
 # file to set keys for XFR authentication
 - name: Create extra config for authenticated XFR request
-  template:
+  ansible.builtin.template:
     src: auth_transfer.j2
     dest: "{{ bind_conf_dir }}/{{ auth_file }}"
     mode: 0640
     owner: root
     group: "{{ bind_group }}"
-  become: yes
-  when: bind_dns_keys is defined and bind_dns_keys|length > 0
-  notify: reload bind
+  become: true
+  when: bind_dns_keys is defined and bind_dns_keys | length > 0
+  notify: Reload bind
   tags: bind
 
 - name: Configure zones
-  include_tasks: zones.yml
+  ansible.builtin.include_tasks: zones.yml
   tags: bind
 
 - name: Main BIND config file
-  template:
+  ansible.builtin.template:
     src: etc_named.conf.j2
     dest: "{{ bind_config }}"
     owner: "{{ bind_owner }}"
     group: "{{ bind_group }}"
     mode: 0640
     setype: named_conf_t
-    validate: 'named-checkconf %s'
-  become: yes
-  notify: reload bind
+    validate: named-checkconf %s
+  become: true
+  notify: Reload bind
   tags: bind
 
 - name: Start BIND service
-  service:
+  ansible.builtin.service:
     name: "{{ bind_service }}"
     state: started
     enabled: true
-  become: yes
+  become: true
   tags: bind

--- a/tasks/zones.yml
+++ b/tasks/zones.yml
@@ -1,11 +1,11 @@
 ---
 - name: Set list of all host IP addresses
-  set_fact:
+  ansible.builtin.set_fact:
     host_all_addresses: "{{ ansible_all_ipv4_addresses | union(ansible_all_ipv6_addresses) }}"
   tags: bind
 
 - name: Read forward zone hashes
-  shell: 'grep -s "^; Hash:" {{ bind_zone_dir }}/{{ item.name }} || true'
+  ansible.builtin.shell: grep -s "^; Hash:" {{ bind_zone_dir }}/{{ item.name }} || true
   changed_when: false
   check_mode: false
   register: forward_hashes_temp
@@ -17,8 +17,8 @@
   tags: bind
 
 - name: Create dict of forward hashes
-  set_fact:
-    forward_hashes: "{{ forward_hashes|default([]) + [ {'hash': item.stdout|default(), 'name': item.item.name} ] }}"
+  ansible.builtin.set_fact:
+    forward_hashes: "{{ forward_hashes | default([]) + [{'hash': item.stdout | default(), 'name': item.item.name}] }}"
   with_items:
     - "{{ forward_hashes_temp.results }}"
   run_once: true
@@ -27,9 +27,9 @@
   tags: bind
 
 - name: Read reverse ipv4 zone hashes
-  shell: "grep -s \"^; Hash:\" {{ bind_zone_dir }}/{{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr.arpa || true"
   changed_when: false
   check_mode: false
+  ansible.builtin.shell: "grep -s \"^; Hash:\" {{ bind_zone_dir }}/{{ ('.'.join(item.1.replace(item.1 + '.', '').split('.')[:: -1])) }}.in-addr.arpa || true"
   register: reverse_hashes_temp
   with_subelements:
     - "{{ bind_zones }}"
@@ -42,18 +42,18 @@
   tags: bind
 
 - name: Create dict of reverse hashes
-  set_fact:
-    reverse_hashes: "{{ reverse_hashes|default([]) + [ {'hash': item.0.stdout|default(), 'network': item.1} ] }}"
+  ansible.builtin.set_fact:
+    reverse_hashes: "{{ reverse_hashes | default([]) + [{'hash':item.0.stdout |default(), 'network':item.1}] }}"
   with_subelements:
     - "{{ reverse_hashes_temp.results }}"
     - item
   run_once: true
   loop_control:
-    label: "{{ item.1.name |default(item.0.cmd.split(' ')[4]) }}"
+    label: "{{ item.1.name | default(item.0.cmd.split(' ')[4]) }}"
   tags: bind
 
 - name: Read reverse ipv6 zone hashes
-  shell: "grep -s \"^; Hash:\" {{ bind_zone_dir }}/{{ (item.1 | ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):-1] }} || true"
+  ansible.builtin.shell: "grep -s \"^; Hash:\" {{ bind_zone_dir }}/{{ (item.1 | ipaddr('revdns'))[-(9 + (item.1 |regex_replace('^.*/', '')|int)//2):-1] }} || true"
   changed_when: false
   check_mode: false
   register: reverse_hashes_ipv6_temp
@@ -68,26 +68,26 @@
   tags: bind
 
 - name: Create dict of reverse ipv6 hashes
-  set_fact:
-    reverse_hashes_ipv6: "{{ reverse_hashes_ipv6|default([]) + [ {'hash': item.0.stdout|default(), 'network': item.1} ] }}"
+  ansible.builtin.set_fact:
+    reverse_hashes_ipv6: "{{ reverse_hashes_ipv6 | default([]) + [{'hash':item.0.stdout |default(), 'network':item.1}] }}"
   with_subelements:
     - "{{ reverse_hashes_ipv6_temp.results }}"
     - item
   run_once: true
   loop_control:
-    label: "{{ item.1.name |default(item.0.cmd.split(' ')[4]) }}"
+    label: "{{ item.1.name | default(item.0.cmd.split(' ')[4]) }}"
   tags: bind
 
 - name: Create forward lookup zone file
-  template:
+  ansible.builtin.template:
     src: bind_zone.j2
     dest: "{{ bind_zone_dir }}/{{ item.name }}"
     owner: "{{ bind_owner }}"
     group: "{{ bind_group }}"
     mode: "{{ bind_zone_file_mode }}"
     setype: named_zone_t
-    validate: 'named-checkzone -d {{ item.name }} %s'
-  become: yes
+    validate: named-checkzone -d {{ item.name }} %s
+  become: true
   with_items:
     - "{{ bind_zones }}"
   loop_control:
@@ -97,19 +97,19 @@
     ((item.type is defined and item.type == 'primary') or
     (item.type is not defined and item.primaries is defined and
     (host_all_addresses | intersect(item.primaries) | length > 0)))
-  notify: reload bind
+  notify: Reload bind
   tags: bind
 
 - name: Create reverse lookup zone file
-  template:
+  ansible.builtin.template:
     src: reverse_zone.j2
-    dest: "{{ bind_zone_dir }}/{{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr.arpa"
+    dest: "{{ bind_zone_dir }}/{{ ('.'.join(item.1.replace(item.1 + '.', '').split('.')[:: -1])) }}.in-addr.arpa"
     owner: "{{ bind_owner }}"
     group: "{{ bind_group }}"
     mode: "{{ bind_zone_file_mode }}"
     setype: named_zone_t
-    validate: "named-checkzone {{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr.arpa %s"
-  become: yes
+    validate: named-checkzone {{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr.arpa %s
+  become: true
   with_subelements:
     - "{{ bind_zones }}"
     - networks
@@ -122,19 +122,19 @@
     ((item[0].type is defined and item[0].type == 'primary') or
     (item[0].type is not defined and item[0].primaries is defined and
     (host_all_addresses | intersect(item[0].primaries) | length > 0)))
-  notify: reload bind
+  notify: Reload bind
   tags: bind
 
 - name: Create reverse IPv6 lookup zone file
-  template:
+  ansible.builtin.template:
     src: reverse_zone_ipv6.j2
-    dest: "{{ bind_zone_dir }}/{{ (item.1 | ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):-1] }}"
+    dest: "{{ bind_zone_dir }}/{{ (item.1 | ipaddr('revdns'))[-(9 + (item.1 |regex_replace('^.*/', '')|int)//2):-1] }}"
     owner: "{{ bind_owner }}"
     group: "{{ bind_group }}"
     mode: "{{ bind_zone_file_mode }}"
     setype: named_zone_t
-    validate: "named-checkzone {{ (item.1 | ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):] }} %s"
-  become: yes
+    validate: named-checkzone {{ (item.1 | ipaddr('revdns'))[-(9+(item.1 | regex_replace('^.*/','') | int)//2):] }} %s
+  become: true
   with_subelements:
     - "{{ bind_zones }}"
     - ipv6_networks
@@ -147,5 +147,5 @@
     ((item[0].type is defined and item[0].type == 'primary') or
     (item[0].type is not defined and item[0].primaries is defined and
     (host_all_addresses | intersect(item[0].primaries) | length > 0)))
-  notify: reload bind
+  notify: Reload bind
   tags: bind

--- a/templates/etc_named.conf.j2
+++ b/templates/etc_named.conf.j2
@@ -38,7 +38,13 @@ options {
 
   rrset-order { order {{ bind_rrset_order }}; };
 
-{% if bind_dnssec_enable %}  dnssec-enable {{ bind_dnssec_enable }};{% endif %}
+{%+ if ansible_distribution == "Ubuntu" and ansible_distribution_version|float >= 22.04 -%}
+  {% if bind_dnssec_enable %} dnssec-enable {{ bind_dnssec_enable }};{% endif %}
+{% elif ansible_distribution == "Debian" and ansible_distribution_version|int >= 10 -%}
+  {% if bind_dnssec_enable %} dnssec-enable {{ bind_dnssec_enable }};{% endif %}
+{% else %}
+  dnssec-enable {{ bind_dnssec_enable }};
+{% endif %}
   dnssec-validation {{ bind_dnssec_validation }};
 
   /* Path to ISC DLV key */
@@ -150,6 +156,23 @@ zone "{{ bind_zone.name }}" IN {
 {% if bind_zone.create_reverse_zones is not defined or bind_zone.create_reverse_zones %}
 {% for network in bind_zone.networks %}
 
+{# Start: set zone type  #}
+{% set _all_addresses = ansible_all_ipv4_addresses | union(ansible_all_ipv6_addresses) %}
+{% if bind_zone.type is defined and bind_zone.type == 'primary' %}
+{% set _type = 'primary' %}
+{% elif bind_zone.type is defined and bind_zone.type == 'secondary' %}
+{% set _type = 'secondary' %}
+{% elif bind_zone.type is defined and bind_zone.type == 'forward' %}
+{% set _type = 'forward' %}
+{% elif bind_zone.type is not defined and bind_zone.primaries is defined and (_all_addresses|intersect(bind_zone.primaries)|length > 0) %}
+{% set _type = 'primary' %}
+{% elif bind_zone.type is not defined and bind_zone.primaries is defined and not (_all_addresses|intersect(bind_zone.primaries)|length > 0) %}
+{% set _type = 'secondary' %}
+{% elif bind_zone.type is not defined and bind_zone.forwarders is defined %}
+{% set _type = 'forward' %}
+{% endif %}
+{# End: set zone type #}
+
 zone "{{ ('.'.join(network.replace(network+'.','').split('.')[::-1])) }}.in-addr.arpa" IN {
 {% if _type == 'primary' %}
   type master;
@@ -207,4 +230,12 @@ zone "{{ (network | ipaddr('revdns'))[-(9+(network|regex_replace('^.*/','')|int)
 {% endif %}
 {% endif %}
 {% endfor %}
+{% endif %}
+
+{% if ansible_os_family == "RedHat" %}
+zone "." IN {
+        type hint;
+        file "{{ bind_dir }}/named.ca";
+};
+{% else %}
 {% endif %}

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -1,6 +1,5 @@
 # Distro specific variables for Arch Linux
 ---
-
 bind_packages:
   - python-netaddr
   - python-dns
@@ -14,19 +13,18 @@ bind_config: /etc/named.conf
 
 # Zone files included in the installation
 bind_default_zone_files: []
-
 # Directory with run-time stuff
 bind_dir: /var/named
 bind_conf_dir: "{{ bind_dir }}"
-auth_file: "auth_transfer.conf"
+auth_file: auth_transfer.conf
 bind_auth_file: "{{ bind_conf_dir }}/{{ auth_file }}"
 
 bind_owner: root
 bind_group: named
 
-bind_bindkeys_file: "/etc/named.iscdlv.key"
-bind_pid_file: "/run/named/named.pid"
-bind_session_keyfile: "/run/named/session.key"
+bind_bindkeys_file: /etc/named.iscdlv.key
+bind_pid_file: /run/named/named.pid
+bind_session_keyfile: /run/named/session.key
 
 # Custom location for zone files
 bind_zone_dir: "{{ bind_dir }}"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,9 +1,9 @@
 # Distro specific variables for Debian
 ---
-bind_default_python_version: '3'
+bind_default_python_version: "3"
 bind_packages:
-  - "{{ ( bind_python_version == '3' ) | ternary( 'python3-netaddr', 'python-netaddr' ) }}"
-  - "{{ ( bind_python_version == '3' ) | ternary( 'python3-dnspython', 'python-dnspython' ) }}"
+  - "{{ (bind_python_version == '3') | ternary('python3-netaddr', 'python-netaddr') }}"
+  - "{{ (bind_python_version == '3') | ternary('python3-dnspython', 'python-dnspython') }}"
   - bind9
   - bind9utils
 
@@ -18,16 +18,16 @@ bind_default_zone_files:
 
 # Directory with run-time stuff
 bind_dir: /var/cache/bind
-bind_conf_dir: "/etc/bind"
-auth_file: "auth_transfer.conf"
+bind_conf_dir: /etc/bind
+auth_file: auth_transfer.conf
 bind_auth_file: "{{ bind_conf_dir }}/{{ auth_file }}"
 
 bind_owner: root
 bind_group: bind
 
-bind_bindkeys_file: "/etc/named.iscdlv.key"
-bind_pid_file: "/run/named/named.pid"
-bind_session_keyfile: "/run/named/session.key"
+bind_bindkeys_file: /etc/named.iscdlv.key
+bind_pid_file: /run/named/named.pid
+bind_session_keyfile: /run/named/session.key
 
 # Custom location for zone files
 bind_zone_dir: "{{ bind_dir }}"

--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -1,6 +1,5 @@
 # Distro specific variables for FreeBSD
 ---
-
 bind_packages:
   - py37-netaddr
   - py37-dnspython
@@ -17,16 +16,16 @@ bind_default_zone_files:
 
 # Directory with run-time stuff
 bind_dir: /var/cache/named
-bind_conf_dir: "/usr/local/etc/namedb/"
-auth_file: "auth_transfer.conf"
+bind_conf_dir: /usr/local/etc/namedb/
+auth_file: auth_transfer.conf
 bind_auth_file: "{{ bind_conf_dir }}/{{ auth_file }}"
 
 bind_owner: bind
 bind_group: bind
 
-bind_bindkeys_file: "/usr/local/etc/namedb/bind.keys"
-bind_pid_file: "/var/run/named/named.pid"
-bind_session_keyfile: "/var/run/named/session.key"
+bind_bindkeys_file: /usr/local/etc/namedb/bind.keys
+bind_pid_file: /var/run/named/named.pid
+bind_session_keyfile: /var/run/named/session.key
 
 # Custom location for zone files
 bind_zone_dir: "{{ bind_dir }}"

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,9 +1,9 @@
 # Distro specific variables for RedHat
 ---
-bind_default_python_version: "{{ ( ansible_distribution_major_version == '8' ) | ternary( '3', '2' ) }}"
+bind_default_python_version: "{{ (ansible_distribution_major_version == '8') | ternary('3', '2') }}"
 bind_packages:
-  - "{{ ( bind_python_version == '3' ) | ternary( 'python3-netaddr', 'python-netaddr' ) }}"
-  - "{{ ( bind_python_version == '3' ) | ternary( 'python3-dns', 'python-dns' ) }}"
+  - "{{ (bind_python_version == '3') | ternary('python3-netaddr', 'python-netaddr') }}"
+  - "{{ (bind_python_version == '3') | ternary('python3-dns', 'python-dns') }}"
   - bind
   - bind-utils
 
@@ -19,17 +19,17 @@ bind_default_zone_files:
 
 # Directory with run-time stuff
 bind_dir: /var/named
-bind_conf_dir: "/etc/named"
-auth_file: "auth_transfer.conf"
+bind_conf_dir: /etc/named
+auth_file: auth_transfer.conf
 bind_auth_file: "{{ bind_conf_dir }}/{{ auth_file }}"
 
 bind_owner: root
 bind_group: named
 
-bind_bindkeys_file: "/etc/named.iscdlv.key"
-bind_pid_file: "/run/named/named.pid"
-bind_session_keyfile: "/run/named/session.key"
+bind_bindkeys_file: /etc/named.iscdlv.key
+bind_pid_file: /run/named/named.pid
+bind_session_keyfile: /run/named/session.key
 
 # Custom location for zone files
-bind_zone_dir: "{{ bind_dir }}"
-bind_secondary_dir: "{{ bind_dir }}/secondary"
+bind_zone_dir: "{{ bind_dir }}/zones"
+bind_secondary_dir: "{{ bind_dir }}/slaves"


### PR DESCRIPTION
 - vars/RedHat.yml:
   + bind_zone dir should be different from bind_zone_dir
 - defaults/main.yml:
   + define bind_log_dir
 - templates/etc_named.conf.j2
   + fix dnssec-enable logic when bind_dnssec_enable is declared
   + support for reverse zone, taken from apatard/ansible-role-bind@324f829
   + Add root nameserver zone
 - Rewrite the code to fix the ansible-lint complaints
   + handlers/main.yml
   + defaults/main.yml
   + molecule/default/verify.yml
   + molecule/shared_inventory/verify.yml
   + tasks/main.yml
   + tasks/zones.yml
 - remove dnssec-enable option in Ubuntu 22.04, Debian 10 and CentOS 8
   or higher