### PR TITLE
Eliminate dnssec-enable option for bind version 9.16 and newer. Fix #192

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -38,6 +38,7 @@ platforms:
     # operate within the container. DO NOT use extended privileges in a
     # production environment!
     privileged: true
+    cgroupns_mode: host
     pre_build_image: true
     # Allocate pseudo-TTY
     tty: true
@@ -56,6 +57,7 @@ platforms:
       - ${PWD}:/etc/ansible/roles/bertvv.bind:ro
       - ${PWD}/library:/root/.ansible/plugins/modules:ro
     privileged: true
+    cgroupns_mode: host
     pre_build_image: true
     tty: true
     environment:
@@ -73,6 +75,7 @@ platforms:
       - ${PWD}:/etc/ansible/roles/bertvv.bind:ro
       - ${PWD}/library:/root/.ansible/plugins/modules:ro
     privileged: true
+    cgroupns_mode: host
     pre_build_image: true
     tty: true
     environment:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,6 +46,21 @@
     - "{{ bind_packages }}"
   tags: bind
 
+- name: Gather the package facts
+  package_facts:
+    manager: auto
+
+- name: Extract installed bind version
+  set_fact:
+    bind_ver_installed: "{{ ansible_facts.packages[bind_package]
+       | map(attribute='version') | first
+       | regex_search('^(.*:)*([0-9]+\\.[0-9]+)\\.(.*)$', '\\2') | first }}"
+
+- name: Discard bind_dnssec_enable for bind >= 9.16
+  set_fact:
+    bind_dnssec_enable: false
+  when: bind_ver_installed is version('9.16', '>=')
+
 - name: Ensure runtime directories referenced in config exist
   file:
     path: "{{ item }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,7 +26,7 @@
 - name: Update package cache for Debian based distros
   apt:
     update_cache: yes
-  become: yes
+  become: true
   changed_when: false
   when: ansible_os_family == 'Debian'
   tags: bind
@@ -41,7 +41,7 @@
   package:
     pkg: "{{ item }}"
     state: present
-  become: yes
+  become: true
   with_items:
     - "{{ bind_packages }}"
   tags: bind
@@ -68,7 +68,7 @@
     owner: "{{ bind_owner }}"
     group: "{{ bind_group }}"
     mode: 0770
-  become: yes
+  become: true
   with_items:
     - "{{ bind_dir }}/dynamic"
     - "{{ bind_dir }}/data"
@@ -83,7 +83,7 @@
     group: "{{ bind_group }}"
     mode: 0770
     setype: named_cache_t
-  become: yes
+  become: true
   tags: bind
 
 - name: Create serial, based on UTC UNIX time
@@ -120,7 +120,7 @@
     mode: 0640
     setype: named_conf_t
     validate: 'named-checkconf %s'
-  become: yes
+  become: true
   notify: reload bind
   tags: bind
 
@@ -129,5 +129,5 @@
     name: "{{ bind_service }}"
     state: started
     enabled: true
-  become: yes
+  become: true
   tags: bind

--- a/tasks/zones.yml
+++ b/tasks/zones.yml
@@ -87,7 +87,7 @@
     mode: "{{ bind_zone_file_mode }}"
     setype: named_zone_t
     validate: 'named-checkzone -d {{ item.name }} %s'
-  become: yes
+  become: true
   with_items:
     - "{{ bind_zones }}"
   loop_control:
@@ -109,7 +109,7 @@
     mode: "{{ bind_zone_file_mode }}"
     setype: named_zone_t
     validate: "named-checkzone {{ ('.'.join(item.1.replace(item.1+'.','').split('.')[::-1])) }}.in-addr.arpa %s"
-  become: yes
+  become: true
   with_subelements:
     - "{{ bind_zones }}"
     - networks
@@ -134,7 +134,7 @@
     mode: "{{ bind_zone_file_mode }}"
     setype: named_zone_t
     validate: "named-checkzone {{ (item.1 | ipaddr('revdns'))[-(9+(item.1|regex_replace('^.*/','')|int)//2):] }} %s"
-  become: yes
+  become: true
   with_subelements:
     - "{{ bind_zones }}"
     - ipv6_networks

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -1,5 +1,6 @@
 # Distro specific variables for Arch Linux
 ---
+bind_package: bind
 
 bind_packages:
   - python-netaddr

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,6 +1,9 @@
 # Distro specific variables for Debian
 ---
 bind_default_python_version: '3'
+
+bind_package: bind9
+
 bind_packages:
   - "{{ ( bind_python_version == '3' ) | ternary( 'python3-netaddr', 'python-netaddr' ) }}"
   - "{{ ( bind_python_version == '3' ) | ternary( 'python3-dnspython', 'python-dnspython' ) }}"

--- a/vars/FreeBSD.yml
+++ b/vars/FreeBSD.yml
@@ -1,6 +1,8 @@
 # Distro specific variables for FreeBSD
 ---
 
+bind_package: bind911
+
 bind_packages:
   - py37-netaddr
   - py37-dnspython

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,6 +1,9 @@
 # Distro specific variables for RedHat
 ---
 bind_default_python_version: "{{ ( ansible_distribution_major_version == '8' ) | ternary( '3', '2' ) }}"
+
+bind_package: bind
+
 bind_packages:
   - "{{ ( bind_python_version == '3' ) | ternary( 'python3-netaddr', 'python-netaddr' ) }}"
   - "{{ ( bind_python_version == '3' ) | ternary( 'python3-dns', 'python-dns' ) }}"


### PR DESCRIPTION
Fix issue #192. In bind version 9.16.0 the dnssec-enable option was made obsolete and in 9.18.0 the option was entirely removed. Patch check installed bind version and set variable bind_dnssec_enable to false if version 9.16 and newer. Since the name of the package is different in operating systems families i added variable bind_package.